### PR TITLE
refactor: 适配 agent 端点路径统一调整

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,20 +21,10 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Agent API代理
+    # Agent API代理（含 SSE 流式端点）
     location /api/agent/ {
         client_max_body_size 10M;
         proxy_pass http://agent:8010/api/agent/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # 算法模型想定式开发 — 代理到 Micro-Agent（SSE 流式）
-    location /api/aml_auto_generate/ {
-        client_max_body_size 10M;
-        proxy_pass http://agent:8010/api/aml_auto_generate/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/views/vertical/scenarioDev/GenericScenarioDev.vue
+++ b/src/views/vertical/scenarioDev/GenericScenarioDev.vue
@@ -403,7 +403,7 @@ export default {
         formData.append('file', rawFile.originFileObj || rawFile)
       }
 
-      streamAgent('/api/aml_auto_generate/generate_code', formData, {
+      streamAgent('/api/agent/aml_auto_generate', formData, {
         onStart: () => {
           this.generateProgress.description = '智能体已启动，正在生成算法模型...'
         },


### PR DESCRIPTION
## Summary
- 前端 API 调用路径从 `/api/aml_auto_generate/generate_code` 改为 `/api/agent/aml_auto_generate`
- nginx 移除独立的 `/api/aml_auto_generate/` proxy location，SSE 相关配置合并到 `/api/agent/` 块

## 关联 PR
- 后端变更：fdueblab/Micro-Agent-V2 对应分支 `refactor/unify-aml-auto-generate-route`

## Test plan
- [ ] 想定式开发页面正常发起请求并接收 SSE 流
- [ ] 其他 agent 端点（服务封装、代码分析等）不受影响

Made with [Cursor](https://cursor.com)