### PR TITLE
ci: 重构全部 workflow + 新增部署 webhook 基础设施

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,76 +1,34 @@
-# docs分支负责文档部署
-name: Deploy docs to Server
+name: Build & Deploy Docs
 
 on:
   push:
-    branches:
-      - docs
+    branches: [docs]
 
 jobs:
-  # 文档构建和推送镜像
-  build-docs:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # 获取完整的git历史，用于lastUpdated功能
+          fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Build and push docs Docker image
-        run: |
-          docker build -f docs/Dockerfile -t polarsnowleopard/ioeb-docs:latest .
-          docker push polarsnowleopard/ioeb-docs:latest
+      - run: |
+          docker build -f docs/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs:latest .
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs:latest
 
-  # 部署到服务器 (依赖所有构建任务完成)
   deploy:
-    needs: [build-docs]
+    name: Deploy
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Deploy to server
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SERVER_IP: ${{ secrets.SERVER_IP }}
-          DOMAIN: ${{ secrets.DOMAIN }}
+      - name: Trigger deploy webhook
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H $SERVER_IP >> ~/.ssh/known_hosts
-
-          # 创建部署目录
-          ssh ubuntu@$SERVER_IP "mkdir -p ~/ioeb"
-
-          # 拷贝配置文件到服务器
-          scp docker-compose.yml ubuntu@$SERVER_IP:~/ioeb/
-          # scp nginx.conf ubuntu@$SERVER_IP:~/ioeb/
-          scp -r api ubuntu@$SERVER_IP:~/ioeb/
-
-          # 确保数据目录存在
-          ssh ubuntu@$SERVER_IP << EOF
-            mkdir -p ~/ioeb/api/Project_1/checkpoint
-            mkdir -p ~/ioeb/api/Project_2/checkpoint
-            mkdir -p ~/ioeb/api/Project-3/data
-            mkdir -p ~/ioeb/api/Project-4/eval_config
-            mkdir -p ~/ioeb/api/Project-4/eval_result
-            mkdir -p ~/ioeb/api/Project-4/graph_dataset
-
-            cd ~/ioeb
-            
-            # 拉取最新镜像
-            sudo docker-compose pull docs
-
-            # 停止并移除现有容器
-            sudo docker-compose down || true
-
-            # 启动所有服务
-            sudo docker-compose up -d
-          EOF
+          curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
+            -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"service":"docs","image":"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs:latest"}'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,89 +1,50 @@
-# 主分支只负责部署前端
-name: Deploy to Server
+name: CI
 
 on:
   push:
-    branches:
-      - master
-      # - zfy
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-  # 前端构建和推送镜像
-  build-frontend:
+  build:
+    name: Build & Push Frontend Image
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
-      - name: Install yarn
-        run: npm install -g yarn
+      - name: Install and build
+        run: |
+          npm install -g yarn
+          yarn install
+          yarn build
 
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Build frontend
-        run: yarn build
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Build and push frontend Docker image
+      - name: Build and push
         run: |
-          docker build -t polarsnowleopard/ioeb-frontend:latest .
-          docker push polarsnowleopard/ioeb-frontend:latest
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend:latest \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend:${SHORT_SHA} .
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend --all-tags
 
-  # 部署到服务器 (依赖所有构建任务完成)
   deploy:
-    needs: [build-frontend]
+    name: Deploy
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Deploy to server
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SERVER_IP: ${{ secrets.SERVER_IP }}
-          DOMAIN: ${{ secrets.DOMAIN }}
+      - name: Trigger deploy webhook
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H $SERVER_IP >> ~/.ssh/known_hosts
-
-          # 创建部署目录
-          ssh ubuntu@$SERVER_IP "mkdir -p ~/ioeb"
-
-          # 拷贝配置文件到服务器
-          scp docker-compose.yml ubuntu@$SERVER_IP:~/ioeb/
-          scp nginx.conf ubuntu@$SERVER_IP:~/ioeb/
-          scp -r api ubuntu@$SERVER_IP:~/ioeb/
-
-          # 确保数据目录存在
-          ssh ubuntu@$SERVER_IP << EOF
-            mkdir -p ~/ioeb/api/Project_1/checkpoint
-            mkdir -p ~/ioeb/api/Project_2/checkpoint
-            mkdir -p ~/ioeb/api/Project-3/data
-            mkdir -p ~/ioeb/api/Project-4/eval_config
-            mkdir -p ~/ioeb/api/Project-4/eval_result
-            mkdir -p ~/ioeb/api/Project-4/graph_dataset
-
-            cd ~/ioeb
-            
-            # 拉取最新镜像
-            sudo docker-compose pull
-
-            # 停止并移除现有容器
-            sudo docker-compose down || true
-
-            # 启动所有服务
-            sudo docker-compose up -d
-          EOF
+          curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
+            -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"service":"frontend","image":"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend:latest"}'

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -1,146 +1,91 @@
-# 涉及服务的更新应由service分支或手动触发
-name: Deploy services to Server
+name: Build & Deploy Services
 
 on:
   push:
-    branches:
-      - service
+    branches: [service]
 
 jobs:
-  # Project_1 构建和推送镜像
   build-project1:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - run: |
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:latest ./api/Project_1
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:latest
 
-      - name: Build and push Project_1 Docker image
-        run: |
-          docker build -t polarsnowleopard/ioeb-project1:latest ./api/Project_1
-          docker push polarsnowleopard/ioeb-project1:latest
-
-  # Project_2 构建和推送镜像
   build-project2:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - run: |
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:latest ./api/Project_2
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:latest
 
-      - name: Build and push Project_1 Docker image
-        run: |
-          docker build -t polarsnowleopard/ioeb-project2:latest ./api/Project_2
-          docker push polarsnowleopard/ioeb-project2:latest
-
-  # Project-3 构建和推送镜像
   build-project3:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - run: |
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:latest ./api/Project-3
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:latest
 
-      - name: Build and push Project-3 Docker image
-        run: |
-          docker build -t polarsnowleopard/ioeb-project3:latest ./api/Project-3
-          docker push polarsnowleopard/ioeb-project3:latest
-
-  # Project-4 构建和推送镜像
   build-project4:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - run: |
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:latest ./api/Project-4
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:latest
 
-      - name: Build and push Project-4 Docker image
-        run: |
-          docker build -t polarsnowleopard/ioeb-project4:latest ./api/Project-4
-          docker push polarsnowleopard/ioeb-project4:latest
-
-  # linezolid 构建和推送镜像
   build-linezolid:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - run: |
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:latest ./api/linezolid
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:latest
 
-      - name: Build and push linezolid Docker image
-        run: |
-          docker build -t polarsnowleopard/ioeb-linezolid:latest ./api/linezolid
-          docker push polarsnowleopard/ioeb-linezolid:latest
-
-  # 部署到服务器 (依赖所有构建任务完成)
   deploy:
+    name: Deploy Services
     needs: [build-project1, build-project2, build-project3, build-project4, build-linezolid]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: project-1
+            image_suffix: ioeb-project1
+          - service: project-2
+            image_suffix: ioeb-project2
+          - service: project-3
+            image_suffix: ioeb-project3
+          - service: project-4
+            image_suffix: ioeb-project4
+          - service: linezolid
+            image_suffix: ioeb-linezolid
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Deploy to server
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SERVER_IP: ${{ secrets.SERVER_IP }}
-          DOMAIN: ${{ secrets.DOMAIN }}
+      - name: Trigger deploy webhook
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H $SERVER_IP >> ~/.ssh/known_hosts
-
-          # 创建部署目录
-          ssh ubuntu@$SERVER_IP "mkdir -p ~/ioeb"
-
-          # 拷贝配置文件到服务器
-          scp docker-compose.yml ubuntu@$SERVER_IP:~/ioeb/
-          # scp nginx.conf ubuntu@$SERVER_IP:~/ioeb/
-          scp -r api ubuntu@$SERVER_IP:~/ioeb/
-
-          # 确保数据目录存在
-          ssh ubuntu@$SERVER_IP << EOF
-            mkdir -p ~/ioeb/api/Project_1/checkpoint
-            mkdir -p ~/ioeb/api/Project_2/checkpoint
-            mkdir -p ~/ioeb/api/Project-3/data
-            mkdir -p ~/ioeb/api/Project-4/eval_config
-            mkdir -p ~/ioeb/api/Project-4/eval_result
-            mkdir -p ~/ioeb/api/Project-4/graph_dataset
-
-            cd ~/ioeb
-            
-            # 拉取最新镜像
-            sudo docker-compose pull
-
-            # 停止并移除现有容器
-            sudo docker-compose down || true
-
-            # 启动所有服务
-            sudo docker-compose up -d
-          EOF
+          curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
+            -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"service":"${{ matrix.service }}","image":"${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.image_suffix }}:latest"}'


### PR DESCRIPTION
## Summary
- **master.yml**: 去掉 SSH/SCP，webhook 只重启 frontend
- **service.yml**: webhook 逐服务部署，不全量 down/up
- **docs.yml**: 去掉 SCP，webhook 只重启 docs
- **新增 `deploy/`**: webhook.py + deploy.sh + systemd unit

## 生产服务器部署步骤
1. 复制 `deploy/` 到服务器 `~/ioeb/deploy/`
2. 修改 `webhook.service` 中 `DEPLOY_TOKEN`
3. `sudo cp ~/ioeb/deploy/webhook.service /etc/systemd/system/`
4. `sudo systemctl enable --now webhook`
5. 防火墙开放 9000 端口
6. 三个仓库 Secrets 添加 `DEPLOY_WEBHOOK_URL` 和 `DEPLOY_TOKEN`

Made with [Cursor](https://cursor.com)