### PR TITLE
fix: 添加 MCP SSE 动态代理解决 HTTPS 混合内容问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - SERVICES_BASE_PATH=/app/data/services
       - PORT_RANGE_START=27000
       - PORT_RANGE_END=28000
-      - SERVICE_HOST_URL=http://fdueblab.cn
+      - SERVICE_HOST_URL=https://fdueblab.cn
     env_file:
       - ./env/backend.env
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,6 +21,21 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # MCP SSE 动态端口代理，将 /mcp-proxy/{port}/{path} 转发到对应端口
+    location ~ ^/mcp-proxy/(\d+)/(.*) {
+        set $mcp_port $1;
+        set $mcp_path $2;
+        resolver 8.8.8.8 valid=30s;
+        proxy_pass http://fdueblab.cn:$mcp_port/$mcp_path$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 300s;
+    }
+
     # Agent API代理（含 SSE 流式端点）
     location /api/agent/ {
         client_max_body_size 10M;


### PR DESCRIPTION
## Summary
- nginx.conf 添加 `/mcp-proxy/{port}/{path}` 动态反向代理 location，将 MCP SSE 请求通过 HTTPS 443 端口转发到对应服务端口
- `docker-compose.yml` 中 `SERVICE_HOST_URL` 从 `http` 改为 `https`

## Test plan
- [ ] 浏览器访问 https://fdueblab.cn 确认不再提示证书不安全/混合内容
- [ ] 验证 MCP SSE 连接通过 `/mcp-proxy/` 路径正常工作