### PR TITLE
feat: 添加用户注册功能并清理登录页安全隐患

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the **frontend** of the "算法模型智能体平台" (AI Algorithm Model Agent Platform) — a Vue 2 SPA for managing algorithm microservices, application building, and intelligent operations across vertical domains. The backend is a separate Flask service (ioeb_backend repo); the agent framework lives in the Micro-Agent repo.
+
+Production URL: https://fdueblab.cn
+
+## Commands
+
+```bash
+# Install dependencies (yarn preferred)
+yarn install
+
+# Dev server (http://localhost:8001)
+yarn serve
+
+# Production build
+yarn build
+
+# Preview build (uses .env.preview)
+yarn build:preview
+
+# Lint (auto-fix)
+yarn lint
+
+# Lint JS only
+yarn lint:js
+
+# Lint CSS/Less only
+yarn lint:css
+
+# Run unit tests
+yarn test:unit
+
+# Documentation dev server (VitePress)
+yarn docs:dev
+```
+
+## Architecture
+
+### Tech Stack
+- **Vue 2.6** + Vue Router (hash mode) + Vuex
+- **Ant Design Vue 1.7** as primary UI framework (also has Element UI for legacy components)
+- **Less** for styling, with Ant Design theme variables
+- **Webpack** via Vue CLI 5
+- **ECharts / AntV G2Plot / G6** for data visualization
+- Path alias: `@$` → `src/`, `@` → `src/`
+
+### Source Layout (`src/`)
+
+- **`api/`** — Axios API modules organized by domain (login, service, docker, evaluation, etc.)
+- **`components/`** — Shared components (Agent chat, Charts, Editor, flow editor `ef/`, monitor dashboards, Table, etc.)
+- **`config/`** — App settings (`defaultSettings.js`) and route definitions (`router.config.js`)
+- **`core/`** — App bootstrap, global directives, icon registration, permission directives
+- **`domain/`** — Domain knowledge system: `KnowledgeRegistry` + `KnowledgeEnhancer` with pluggable profiles per vertical domain (aml, aircraft, health, agriculture, evtol, ecommerce, homeAI)
+- **`layouts/`** — Page layout shells: BasicLayout (main sidebar+header), BlankLayout, UserLayout (login), AppView, PageView
+- **`locales/`** — i18n (zh-CN / en-US)
+- **`router/`** — Vue Router setup; routes are dynamically generated from `asyncRouterMap` filtered by user permissions
+- **`store/`** — Vuex modules: `user` (auth/token), `app` (settings), `async-router` (permission-based routing)
+- **`utils/`** — HTTP client (`request.js`), dictionary cache, code generators, validators
+- **`views/`** — Page views organized by feature area
+
+### Key Architectural Patterns
+
+**Dynamic routing by domain**: Routes under `/vertical-user/`, `/vertical-ms/`, `/vertical-scenario-dev/`, `/vertical-atom-app/`, `/evaluation/`, `/operation/` are generated dynamically from the backend dictionary API (`loadDict('domain')`). A shared `GenericVerticalDomain.vue` / `GenericMicroService.vue` / `GenericScenarioDev.vue` renders each domain by accepting a `verticalType` prop.
+
+**Permission system**: Three roles — `admin`, `publisher`, `user`. Route meta `permission` arrays control visibility. The Vuex `async-router` module filters `asyncRouterMap` based on the logged-in user's role.
+
+**Auth flow**: Token stored via `store` (localStorage with expiry). Header `Access-Token` sent on every request. On 401, auto-logout and reload.
+
+**HTTP clients**: `src/utils/request.js` exports the standard Axios instance (baseURL from `VUE_APP_API_BASE_URL`), plus `streamAgent` / `callAgentApi` / `streamLLMChat` for SSE streaming to the agent service (baseURL from `VUE_APP_AGENT_BASE_URL`).
+
+**Domain knowledge**: `src/domain/` provides a registry of vertical-domain profiles. Call `getKnowledge(domainId, context)` to retrieve domain-specific metadata (prompts, service catalogs, terminology) used by the AI assistant and scenario builder components.
+
+**Dictionary cache**: `src/utils/dictionaryCache.js` caches backend dictionary data in localStorage with 24h expiry. Used heavily for dynamic route generation and dropdown options.
+
+### Top-level `api/` Directory
+
+Contains standalone algorithm microservice projects (Project_1 through Project_4, linezolid, llm) — each is a Python Flask app with its own Dockerfile. These are NOT part of the Vue frontend build; they are deployed as separate containers.
+
+## Deployment
+
+- CI: GitHub Actions (`.github/workflows/master.yml`) — on push to master: yarn build → Docker image → deploy webhook
+- Docker: `Dockerfile` builds the frontend into an nginx image; `docker-compose.yml` orchestrates frontend + backend + agent + algorithm services
+- The frontend nginx serves on ports 80/443 and reverse-proxies to backend services
+
+## Code Style
+
+- ESLint: `plugin:vue/strongly-recommended` + `@vue/standard`
+- No semicolons, single quotes, no trailing commas
+- Commit messages follow Conventional Commits: `feat|fix|docs|style|refactor|test|chore|revert`
+- Husky + lint-staged for pre-commit checks

--- a/src/api/login.js
+++ b/src/api/login.js
@@ -31,6 +31,14 @@ export function getSmsCaptcha (parameter) {
   })
 }
 
+export function register (parameter) {
+  return request({
+    url: userApi.Register,
+    method: 'post',
+    data: parameter
+  })
+}
+
 export function getInfo (parameter) {
   let url = ''
   if (parameter === 'user') {

--- a/src/locales/lang/en-US/user.js
+++ b/src/locales/lang/en-US/user.js
@@ -1,8 +1,8 @@
 export default {
   'user.login.userName': 'userName',
   'user.login.password': 'password',
-  'user.login.username.placeholder': 'Account: issuer',
-  'user.login.password.placeholder': 'password: admin',
+  'user.login.username.placeholder': 'Please enter your username',
+  'user.login.password.placeholder': 'Please enter your password',
   'user.login.message-invalid-credentials':
     'Invalid username or password',
   'user.login.message-invalid-verification-code': 'Invalid verification code',

--- a/src/locales/lang/zh-CN/user.js
+++ b/src/locales/lang/zh-CN/user.js
@@ -1,8 +1,8 @@
 export default {
   'user.login.userName': '用户名',
   'user.login.password': '密码',
-  'user.login.username.placeholder': '账户: issuer',
-  'user.login.password.placeholder': '密码: admin',
+  'user.login.username.placeholder': '请输入账户名',
+  'user.login.password.placeholder': '请输入密码',
   'user.login.message-invalid-credentials': '账户或密码错误',
   'user.login.message-invalid-verification-code': '验证码错误',
   'user.login.tab-login-credentials': '账户密码登录',

--- a/src/views/user/Login.vue
+++ b/src/views/user/Login.vue
@@ -87,6 +87,7 @@
           :loading="state.loginBtn"
           :disabled="state.loginBtn"
         >{{ $t('user.login.login') }}</a-button>
+        <router-link class="register" :to="{ name: 'register' }">{{ $t('user.login.signup') }}</router-link>
       </a-form-item>
     </a-form>
 
@@ -275,6 +276,11 @@ export default {
     font-size: 16px;
     height: 40px;
     width: 100%;
+  }
+
+  .register {
+    float: right;
+    line-height: 40px;
   }
 
   .user-login-other {

--- a/src/views/user/Register.vue
+++ b/src/views/user/Register.vue
@@ -6,9 +6,22 @@
         <a-input
           size="large"
           type="text"
-          :placeholder="$t('user.register.email.placeholder')"
-          v-decorator="['email', {rules: [{ required: true, type: 'email', message: $t('user.email.required') }], validateTrigger: ['change', 'blur']}]"
-        ></a-input>
+          placeholder="请输入用户名"
+          v-decorator="['username', {rules: [{ required: true, message: '请输入用户名' }, { min: 3, max: 50, message: '用户名长度需在 3-50 个字符之间' }], validateTrigger: ['change', 'blur']}]"
+        >
+          <a-icon slot="prefix" type="user" :style="{ color: 'rgba(0,0,0,.25)' }"/>
+        </a-input>
+      </a-form-item>
+
+      <a-form-item>
+        <a-input
+          size="large"
+          type="text"
+          placeholder="请输入姓名（选填，默认与用户名相同）"
+          v-decorator="['name', {rules: [], validateTrigger: ['change', 'blur']}]"
+        >
+          <a-icon slot="prefix" type="idcard" :style="{ color: 'rgba(0,0,0,.25)' }"/>
+        </a-input>
       </a-form-item>
 
       <a-popover
@@ -17,12 +30,11 @@
         :getPopupContainer="(trigger) => trigger.parentElement"
         v-model="state.passwordLevelChecked">
         <template slot="content">
-          <div :style="{ width: '240px' }" >
+          <div :style="{ width: '240px' }">
             <div :class="['user-register', passwordLevelClass]">{{ $t(passwordLevelName) }}</div>
-            <a-progress :percent="state.percent" :showInfo="false" :strokeColor=" passwordLevelColor " />
+            <a-progress :percent="state.percent" :showInfo="false" :strokeColor="passwordLevelColor" />
             <div style="margin-top: 10px;">
-              <span>{{ $t('user.register.password.popover-message') }}
-              </span>
+              <span>{{ $t('user.register.password.popover-message') }}</span>
             </div>
           </div>
         </template>
@@ -30,55 +42,25 @@
           <a-input-password
             size="large"
             @click="handlePasswordInputClick"
-            :placeholder="$t('user.register.password.placeholder')"
-            v-decorator="['password', {rules: [{ required: true, message: $t('user.password.required') }, { validator: this.handlePasswordLevel }], validateTrigger: ['change', 'blur']}]"
-          ></a-input-password>
+            placeholder="请输入密码"
+            v-decorator="['password', {rules: [{ required: true, message: '请输入密码' }, { validator: this.handlePasswordLevel }], validateTrigger: ['change', 'blur']}]"
+          >
+            <a-icon slot="prefix" type="lock" :style="{ color: 'rgba(0,0,0,.25)' }"/>
+          </a-input-password>
         </a-form-item>
       </a-popover>
 
       <a-form-item>
         <a-input-password
           size="large"
-          :placeholder="$t('user.register.confirm-password.placeholder')"
-          v-decorator="['password2', {rules: [{ required: true, message: $t('user.password.required') }, { validator: this.handlePasswordCheck }], validateTrigger: ['change', 'blur']}]"
-        ></a-input-password>
+          placeholder="请确认密码"
+          v-decorator="['password2', {rules: [{ required: true, message: '请确认密码' }, { validator: this.handlePasswordCheck }], validateTrigger: ['change', 'blur']}]"
+        >
+          <a-icon slot="prefix" type="lock" :style="{ color: 'rgba(0,0,0,.25)' }"/>
+        </a-input-password>
       </a-form-item>
 
-      <a-form-item>
-        <a-input size="large" :placeholder="$t('user.login.mobile.placeholder')" v-decorator="['mobile', {rules: [{ required: true, message: $t('user.phone-number.required'), pattern: /^1[3456789]\d{9}$/ }, { validator: this.handlePhoneCheck } ], validateTrigger: ['change', 'blur'] }]">
-          <a-select slot="addonBefore" size="large" defaultValue="+86">
-            <a-select-option value="+86">+86</a-select-option>
-            <a-select-option value="+87">+87</a-select-option>
-          </a-select>
-        </a-input>
-      </a-form-item>
-      <!--<a-input-group size="large" compact>
-            <a-select style="width: 20%" size="large" defaultValue="+86">
-              <a-select-option value="+86">+86</a-select-option>
-              <a-select-option value="+87">+87</a-select-option>
-            </a-select>
-            <a-input style="width: 80%" size="large" placeholder="11 位手机号"></a-input>
-          </a-input-group>-->
-
-      <a-row :gutter="16">
-        <a-col class="gutter-row" :span="16">
-          <a-form-item>
-            <a-input size="large" type="text" :placeholder="$t('user.login.mobile.verification-code.placeholder')" v-decorator="['captcha', {rules: [{ required: true, message: '请输入验证码' }], validateTrigger: 'blur'}]">
-              <a-icon slot="prefix" type="mail" :style="{ color: 'rgba(0,0,0,.25)' }"/>
-            </a-input>
-          </a-form-item>
-        </a-col>
-        <a-col class="gutter-row" :span="8">
-          <a-button
-            class="getCaptcha"
-            size="large"
-            :disabled="state.smsSendBtn"
-            @click.stop.prevent="getCaptcha"
-            v-text="!state.smsSendBtn && $t('user.register.get-verification-code')||(state.time+' s')"></a-button>
-        </a-col>
-      </a-row>
-
-      <a-form-item>
+      <a-form-item style="margin-top:24px">
         <a-button
           size="large"
           type="primary"
@@ -96,7 +78,7 @@
 </template>
 
 <script>
-import { getSmsCaptcha } from '@/api/login'
+import { register } from '@/api/login'
 import { deviceMixin } from '@/store/device-mixin'
 import { scorePassword } from '@/utils/util'
 
@@ -120,21 +102,15 @@ const levelColor = {
 }
 export default {
   name: 'Register',
-  components: {
-  },
   mixins: [deviceMixin],
   data () {
     return {
       form: this.$form.createForm(this),
-
       state: {
-        time: 60,
         level: 0,
-        smsSendBtn: false,
         passwordLevel: 0,
         passwordLevelChecked: false,
-        percent: 10,
-        progressColor: '#FF0000'
+        percent: 10
       },
       registerBtn: false
     }
@@ -153,18 +129,17 @@ export default {
   methods: {
     handlePasswordLevel (rule, value, callback) {
       if (!value) {
-       return callback()
+        return callback()
       }
-      console.log('scorePassword ; ', scorePassword(value))
       if (value.length >= 6) {
         if (scorePassword(value) >= 30) {
           this.state.level = 1
         }
         if (scorePassword(value) >= 60) {
-        this.state.level = 2
+          this.state.level = 2
         }
         if (scorePassword(value) >= 80) {
-        this.state.level = 3
+          this.state.level = 3
         }
       } else {
         this.state.level = 0
@@ -172,27 +147,17 @@ export default {
       }
       this.state.passwordLevel = this.state.level
       this.state.percent = this.state.level * 33
-
       callback()
     },
 
     handlePasswordCheck (rule, value, callback) {
       const password = this.form.getFieldValue('password')
-      // console.log('value', value)
       if (value === undefined) {
-        callback(new Error(this.$t('user.password.required')))
+        callback(new Error('请确认密码'))
       }
       if (value && password && value.trim() !== password.trim()) {
         callback(new Error(this.$t('user.password.twice.msg')))
       }
-      callback()
-    },
-
-    handlePhoneCheck (rule, value, callback) {
-      console.log('handlePhoneCheck, rule:', rule)
-      console.log('handlePhoneCheck, value', value)
-      console.log('handlePhoneCheck, callback', callback)
-
       callback()
     },
 
@@ -205,64 +170,34 @@ export default {
     },
 
     handleSubmit () {
-      const { form: { validateFields }, state, $router } = this
-      validateFields({ force: true }, (err, values) => {
+      const { form: { validateFields } } = this
+      this.registerBtn = true
+      validateFields(['username', 'name', 'password', 'password2'], { force: true }, (err, values) => {
         if (!err) {
-          state.passwordLevelChecked = false
-          $router.push({ name: 'registerResult', params: { ...values } })
-        }
-      })
-    },
-
-    getCaptcha (e) {
-      e.preventDefault()
-      const { form: { validateFields }, state, $message, $notification } = this
-
-      validateFields(['mobile'], { force: true },
-        (err, values) => {
-          if (!err) {
-            state.smsSendBtn = true
-
-            const interval = window.setInterval(() => {
-              if (state.time-- <= 0) {
-                state.time = 60
-                state.smsSendBtn = false
-                window.clearInterval(interval)
-              }
-            }, 1000)
-
-            const hide = $message.loading('验证码发送中..', 0)
-
-            getSmsCaptcha({ mobile: values.mobile }).then(res => {
-              setTimeout(hide, 2500)
-              $notification['success']({
-                message: '提示',
-                description: '验证码获取成功，您的验证码为：' + res.result.captcha,
-                duration: 8
-              })
-            }).catch(err => {
-              setTimeout(hide, 1)
-              clearInterval(interval)
-              state.time = 60
-              state.smsSendBtn = false
-              this.requestFailed(err)
+          register({
+            username: values.username,
+            password: values.password,
+            name: values.name || values.username
+          }).then(() => {
+            this.$notification.success({
+              message: '注册成功',
+              description: '请使用新账户登录'
             })
-          }
+            this.$router.push({ name: 'login' })
+          }).catch(err => {
+            const msg = (err.response && err.response.data && err.response.data.message) || err.message || '注册失败，请稍后再试'
+            this.$notification.error({
+              message: '注册失败',
+              description: msg,
+              duration: 4
+            })
+          }).finally(() => {
+            this.registerBtn = false
+          })
+        } else {
+          this.registerBtn = false
         }
-      )
-    },
-    requestFailed (err) {
-      this.$notification['error']({
-        message: '错误',
-        description: ((err.response || {}).data || {}).message || '请求出现错误，请稍后再试',
-        duration: 4
       })
-      this.registerBtn = false
-    }
-  },
-  watch: {
-    'state.passwordLevel' (val) {
-      console.log(val)
     }
   }
 }
@@ -296,12 +231,6 @@ export default {
     & > h3 {
       font-size: 16px;
       margin-bottom: 20px;
-    }
-
-    .getCaptcha {
-      display: block;
-      width: 100%;
-      height: 40px;
     }
 
     .register-button {


### PR DESCRIPTION
## Summary
  - Register.vue 重写为用户名/姓名/密码表单，对接后端注册 API
  - Login.vue 添加注册账户链接
  - 清除 i18n 中 placeholder 里的明文凭据
  - 新增 CLAUDE.md

  ## Test plan
  - [ ] 登录页 placeholder 不再显示明文凭据
  - [ ] 注册流程正常工作
  - [ ] 新注册账户角色为 AppDev（publisher+user）