### PR TITLE
[codex] Fix frontend and docs deploy image tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,17 @@ name: Build & Deploy Docs
 
 on:
   push:
-    branches: [docs]
+    branches: [master, docs]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,17 +24,24 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - run: |
-          docker build -f docs/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs:latest .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs:latest
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build -f docs/Dockerfile \
+            -t "${IMAGE_REPO}:latest" \
+            -t "${IMAGE_REPO}:${SHORT_SHA}" .
+          docker push "${IMAGE_REPO}:latest"
+          docker push "${IMAGE_REPO}:${SHORT_SHA}"
 
   deploy:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    env:
+      IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs
     steps:
       - name: Trigger deploy webhook
         run: |
+          SHORT_SHA=${GITHUB_SHA::7}
           curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"service":"docs","image":"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs:latest"}'
+            -d "{\"service\":\"docs\",\"image\":\"${IMAGE_REPO}:${SHORT_SHA}\"}"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,8 @@ jobs:
     name: Build & Push Frontend Image
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend
     steps:
       - uses: actions/checkout@v4
 
@@ -33,18 +35,22 @@ jobs:
         run: |
           SHORT_SHA=${GITHUB_SHA::7}
           docker build \
-            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend:latest \
-            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend:${SHORT_SHA} .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend --all-tags
+            -t "${IMAGE_REPO}:latest" \
+            -t "${IMAGE_REPO}:${SHORT_SHA}" .
+          docker push "${IMAGE_REPO}:latest"
+          docker push "${IMAGE_REPO}:${SHORT_SHA}"
 
   deploy:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    env:
+      IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend
     steps:
       - name: Trigger deploy webhook
         run: |
+          SHORT_SHA=${GITHUB_SHA::7}
           curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"service":"frontend","image":"${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend:latest"}'
+            -d "{\"service\":\"frontend\",\"image\":\"${IMAGE_REPO}:${SHORT_SHA}\"}"


### PR DESCRIPTION
## Summary
- Deploy frontend and docs using immutable short-SHA image tags instead of reusing `latest` in webhook payloads.
- Trigger docs deployment from `master` when `docs/**` changes, while retaining the existing `docs` branch trigger.
- Add manual dispatch for docs deployment.

## Why
Recent `master` deployments built new frontend images, but production still served an older frontend bundle. The docs workflow also only listened to the `docs` branch, so docs merged into `master` did not deploy.

## Validation
- `git diff --check`
- Parsed `.github/workflows/master.yml` and `.github/workflows/docs.yml` with Ruby YAML loader.
- Confirmed the commit contains only the two workflow files and no co-author trailer.
