### PR TITLE
[codex] use sha tags for service deploys

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -14,8 +14,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:latest ./api/Project_1
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:latest \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:${SHORT_SHA} \
+            ./api/Project_1
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:${SHORT_SHA}
 
   build-project2:
     runs-on: ubuntu-latest
@@ -26,8 +31,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:latest ./api/Project_2
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:latest \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:${SHORT_SHA} \
+            ./api/Project_2
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:${SHORT_SHA}
 
   build-project3:
     runs-on: ubuntu-latest
@@ -38,8 +48,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:latest ./api/Project-3
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:latest \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:${SHORT_SHA} \
+            ./api/Project-3
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:${SHORT_SHA}
 
   build-project4:
     runs-on: ubuntu-latest
@@ -50,8 +65,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:latest ./api/Project-4
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:latest \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:${SHORT_SHA} \
+            ./api/Project-4
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:${SHORT_SHA}
 
   build-linezolid:
     runs-on: ubuntu-latest
@@ -62,8 +82,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:latest ./api/linezolid
+          SHORT_SHA=${GITHUB_SHA::7}
+          docker build \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:latest \
+            -t ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:${SHORT_SHA} \
+            ./api/linezolid
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:latest
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-linezolid:${SHORT_SHA}
 
   deploy:
     name: Deploy Services
@@ -85,7 +110,8 @@ jobs:
     steps:
       - name: Trigger deploy webhook
         run: |
+          SHORT_SHA=${GITHUB_SHA::7}
           curl -sf -X POST "${{ secrets.DEPLOY_WEBHOOK_URL }}" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"service":"${{ matrix.service }}","image":"${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.image_suffix }}:latest"}'
+            -d "{\"service\":\"${{ matrix.service }}\",\"image\":\"${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.image_suffix }}:${SHORT_SHA}\"}"


### PR DESCRIPTION
## Summary
- build service images with both `latest` and commit short SHA tags
- deploy project-1, project-2, project-3, project-4, and linezolid using the short SHA image tag

## Why
The deploy server can receive stale `latest` images from Docker Hub/mirrors. Sending immutable short SHA tags to the webhook makes service deployments use the exact CI artifacts.

## Validation
- Parsed `.github/workflows/service.yml` as YAML
- Pushed branch `codex/deploy-service-sha-tags`

## Notes
Existing frontend/docs workflows already deploy short SHA tags and were left unchanged. The untracked local `AGENTS.md` file was not included.
