### PR TITLE
Add global vertical domain selector

### DIFF
--- a/src/components/GlobalHeader/DomainSelector.vue
+++ b/src/components/GlobalHeader/DomainSelector.vue
@@ -1,0 +1,97 @@
+<template>
+  <span v-if="domains.length">
+    <a-dropdown placement="bottomRight" :trigger="['click']">
+      <span class="domain-selector">
+        <a-icon type="cluster" />
+        <span class="domain-selector__text">{{ currentDomainText }}</span>
+        <a-icon type="down" />
+      </span>
+      <template v-slot:overlay>
+        <a-menu :selected-keys="[currentDomainCode]" @click="handleSelect">
+          <a-menu-item v-for="domain in domains" :key="domain.code">
+            {{ domain.text }}
+          </a-menu-item>
+        </a-menu>
+      </template>
+    </a-dropdown>
+  </span>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { loadDict } from '@/utils/dictionaryCache'
+import {
+  DEFAULT_DOMAIN,
+  isDomainRoutedPath,
+  replaceDomainInPath,
+  resolveCurrentDomain
+} from '@/utils/domainContext'
+
+export default {
+  name: 'DomainSelector',
+  data () {
+    return {
+      domains: [DEFAULT_DOMAIN]
+    }
+  },
+  computed: {
+    ...mapGetters(['currentDomain', 'currentDomainCode', 'roles']),
+    currentDomainText () {
+      const matched = this.domains.find(domain => domain.code === this.currentDomainCode)
+      return (matched && matched.text) || (this.currentDomain && this.currentDomain.text) || DEFAULT_DOMAIN.text
+    },
+    permissionList () {
+      return (this.roles && this.roles.permissionList) || []
+    }
+  },
+  created () {
+    this.loadDomains()
+  },
+  methods: {
+    async loadDomains () {
+      const domains = await loadDict('domain', [DEFAULT_DOMAIN])
+      this.domains = domains && domains.length ? domains : [DEFAULT_DOMAIN]
+      const currentDomain = resolveCurrentDomain(this.domains, this.currentDomainCode)
+      this.$store.dispatch('SetCurrentDomain', currentDomain)
+    },
+    handleSelect ({ key }) {
+      if (!key || key === this.currentDomainCode) {
+        return
+      }
+
+      const domain = this.domains.find(item => item.code === key)
+      if (!domain) {
+        return
+      }
+
+      this.$store.dispatch('SetCurrentDomain', domain)
+      if (!isDomainRoutedPath(this.$route.path)) {
+        return
+      }
+
+      const nextPath = replaceDomainInPath(this.$route.path, domain.code, this.permissionList)
+      if (nextPath && nextPath !== this.$route.path) {
+        this.$router.push({ path: nextPath, query: this.$route.query }).catch(() => {})
+      }
+    }
+  }
+}
+</script>
+
+<style lang="less" scoped>
+.domain-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+  max-width: 220px;
+  padding: 0 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.domain-selector__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/components/GlobalHeader/RightContent.vue
+++ b/src/components/GlobalHeader/RightContent.vue
@@ -1,5 +1,6 @@
 <template>
   <div :class="wrpCls">
+    <domain-selector :class="prefixCls" />
     <avatar-dropdown :menu="showMenu" :current-user="currentUser" :class="prefixCls" />
     <select-lang :class="prefixCls" />
   </div>
@@ -8,11 +9,13 @@
 <script>
 import { mapGetters } from 'vuex'
 import AvatarDropdown from './AvatarDropdown'
+import DomainSelector from './DomainSelector'
 import SelectLang from '@/components/SelectLang'
 export default {
   name: 'RightContent',
   components: {
     AvatarDropdown,
+    DomainSelector,
     SelectLang
   },
   props: {

--- a/src/config/router.config.js
+++ b/src/config/router.config.js
@@ -533,7 +533,7 @@ export const asyncRouterMap = [
       // 垂域元应用仿真构建 - 从字典动态获取
       {
         path: '/vertical-meta-app',
-        name: 'vertical-ms',
+        name: 'vertical-meta-app',
         redirect: '/vertical-atom-app/aml', // 默认重定向，会在路由初始化时被更新
         component: RouteView,
         meta: {

--- a/src/layouts/BasicLayout.vue
+++ b/src/layouts/BasicLayout.vue
@@ -44,13 +44,15 @@
 <script>
 import { SettingDrawer, updateTheme } from '@ant-design-vue/pro-layout'
 import { i18nRender } from '@/locales'
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import { CONTENT_WIDTH_TYPE, SIDEBAR_TYPE, TOGGLE_MOBILE_TYPE } from '@/store/mutation-types'
+import cloneDeep from 'lodash.clonedeep'
 
 import defaultSettings from '@/config/defaultSettings'
 import RightContent from '@/components/GlobalHeader/RightContent'
 import UserProfileSurvey from '@/components/UserProfileSurvey'
 import { isSurveyDone } from '@/api/userProfile'
+import { projectDomainMenus } from '@/utils/domainContext'
 // import { asyncRouterMap } from '@/config/router.config.js'
 export default {
   name: 'BasicLayout',
@@ -67,8 +69,6 @@ export default {
       // isDev: this.$route.query.isDev === 'true' || process.env.NODE_ENV === 'development' || process.env.VUE_APP_PREVIEW === 'true',
       isDev: this.$route.query.isDev === 'true',
 
-      // base
-      menus: [],
       // 侧栏收起状态
       collapsed: false,
       settings: {
@@ -102,12 +102,18 @@ export default {
     ...mapState({
       // 动态主路由
       mainMenu: (state) => state.permission.addRouters
-    })
+    }),
+    ...mapGetters(['currentDomainCode', 'roles']),
+    permissionList () {
+      return (this.roles && this.roles.permissionList) || []
+    },
+    menus () {
+      const routes = this.mainMenu.find((item) => item.path === '/')
+      const children = cloneDeep((routes && routes.children) || [])
+      return projectDomainMenus(children, this.currentDomainCode, this.permissionList)
+    }
   },
   created() {
-    const routes = this.mainMenu.find((item) => item.path === '/')
-    // const routes = asyncRouterMap.find((item) => item.path === '/')
-    this.menus = (routes && routes.children) || []
     // const username = localStorage.getItem('username')
     // if (username === 'user') {
     //   this.subTitle = '应用平台'

--- a/src/permission.js
+++ b/src/permission.js
@@ -7,22 +7,20 @@ import notification from 'ant-design-vue/es/notification'
 import { setDocumentTitle, domTitle } from '@/utils/domUtil'
 import { ACCESS_TOKEN } from '@/store/mutation-types'
 import { i18nRender } from '@/locales'
-import { preloadAllDict } from '@/utils/dictionaryCache' // 引入字典预加载功能
+import { loadDict, preloadAllDict } from '@/utils/dictionaryCache' // 引入字典预加载功能
+import {
+  getCurrentDomainCode,
+  getDomainModuleEntryPath,
+  resolveCurrentDomain
+} from '@/utils/domainContext'
 import {
   generateVerticalUserRoutes,
-  getFirstVerticalUserPath,
   generateVerticalMSRoutes,
-  getFirstMSPath,
   generateVerticalScenarioDevRoutes,
-  getFirstScenarioDevPath,
   generateVerticalAppRoutes,
-  getFirstAppPath,
   generateGuideRoutes,
   generateEvaluationRoutes,
-  getFirstEvaluationPath,
-  generateOperationRoutes,
-  getFirstOperationPath,
-  getFirstTechnologyPath
+  generateOperationRoutes
 } from '@/config/router.config' // 引入动态生成路由函数
 
 NProgress.configure({ showSpinner: false }) // NProgress Configuration
@@ -50,6 +48,9 @@ router.beforeEach(async (to, from, next) => {
           await preloadAllDict().catch(err => {
             console.error('预加载字典数据失败:', err)
           })
+          const domainOptions = await loadDict('domain', [])
+          const currentDomain = resolveCurrentDomain(domainOptions)
+          await store.dispatch('SetCurrentDomain', currentDomain)
           // 根据用户权限信息生成可访问的路由表
           await store.dispatch('GenerateRoutes', { token, ...res })
           // 重置路由 防止退出重新登录或者 token 过期后页面未刷新，导致的路由重复添加
@@ -63,7 +64,7 @@ router.beforeEach(async (to, from, next) => {
               const verticalUserRoute = router.children.find(route => route.path === '/vertical-user')
               if (verticalUserRoute) {
                 // 获取第一个垂域路径作为重定向路径
-                verticalUserRoute.redirect = await getFirstVerticalUserPath()
+                verticalUserRoute.redirect = () => getDomainModuleEntryPath('/vertical-user', getCurrentDomainCode())
                 // 动态生成垂域路由
                 verticalUserRoute.children = await generateVerticalUserRoutes()
               }
@@ -74,7 +75,7 @@ router.beforeEach(async (to, from, next) => {
                 const verticalMSRoute = router.children.find(route => route.path === '/vertical-ms')
                 if (verticalMSRoute) {
                   // 获取第一个微服务路径作为重定向路径
-                  verticalMSRoute.redirect = await getFirstMSPath()
+                  verticalMSRoute.redirect = () => getDomainModuleEntryPath('/vertical-ms', getCurrentDomainCode())
                   // 动态生成微服务路由
                   const allMSRoutes = await generateVerticalMSRoutes()
 
@@ -104,7 +105,7 @@ router.beforeEach(async (to, from, next) => {
                   store.getters.roles.permissionList.includes('publisher')) {
                 const verticalScenarioDevRoute = router.children.find(route => route.path === '/vertical-scenario-dev')
                 if (verticalScenarioDevRoute) {
-                  verticalScenarioDevRoute.redirect = await getFirstScenarioDevPath()
+                  verticalScenarioDevRoute.redirect = () => getDomainModuleEntryPath('/vertical-scenario-dev', getCurrentDomainCode())
                   verticalScenarioDevRoute.children = await generateVerticalScenarioDevRoutes()
                 }
               }
@@ -112,7 +113,7 @@ router.beforeEach(async (to, from, next) => {
               const verticalAppRoute = router.children.find(route => route.path === '/vertical-meta-app')
               if (verticalAppRoute) {
                 // 获取第一个元应用路径作为重定向路径
-                verticalAppRoute.redirect = await getFirstAppPath()
+                verticalAppRoute.redirect = () => getDomainModuleEntryPath('/vertical-meta-app', getCurrentDomainCode())
                 // 动态生成元应用路由
                 verticalAppRoute.children = await generateVerticalAppRoutes()
               }
@@ -124,10 +125,10 @@ router.beforeEach(async (to, from, next) => {
                     (store.getters.roles.permissionList.includes('admin') ||
                      store.getters.roles.permissionList.includes('publisher'))) {
                   // admin或publisher权限的用户重定向到技术评测页面
-                  verticalEvaluationRoute.redirect = await getFirstTechnologyPath()
+                  verticalEvaluationRoute.redirect = () => getDomainModuleEntryPath('/evaluation', getCurrentDomainCode(), store.getters.roles.permissionList)
                 } else {
                   // user权限的用户只能重定向到元应用业务数据验证页面
-                  verticalEvaluationRoute.redirect = await getFirstEvaluationPath()
+                  verticalEvaluationRoute.redirect = () => getDomainModuleEntryPath('/evaluation', getCurrentDomainCode(), store.getters.roles.permissionList)
                 }
                 // 动态生成技术评测与业务验证路由
                 const allEvaluationRoutes = await generateEvaluationRoutes()
@@ -160,7 +161,7 @@ router.beforeEach(async (to, from, next) => {
                 const verticalOperationRoute = router.children.find(route => route.path === '/operation')
                 if (verticalOperationRoute) { // 修正变量名
                   // 获取第一个路径作为重定向路径
-                  verticalOperationRoute.redirect = await getFirstOperationPath()
+                  verticalOperationRoute.redirect = () => getDomainModuleEntryPath('/operation', getCurrentDomainCode(), store.getters.roles.permissionList)
                   // 动态生成运维管理路由
                   const allOperationRoutes = await generateOperationRoutes()
 

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -11,6 +11,8 @@ const getters = {
   userInfo: state => state.user.info,
   userProfile: state => state.userProfile.profile,
   profileCompletion: state => state.userProfile.completion,
+  currentDomain: state => state.app.currentDomain,
+  currentDomainCode: state => state.app.currentDomain && state.app.currentDomain.code,
   addRouters: state => state.permission.addRouters,
   multiTab: state => state.app.multiTab
 }

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -11,10 +11,12 @@ import {
   TOGGLE_COLOR,
   TOGGLE_WEAK,
   TOGGLE_MULTI_TAB,
+  CURRENT_DOMAIN,
   // i18n
   APP_LANGUAGE
 } from '@/store/mutation-types'
 import { loadLanguageAsync } from '@/locales'
+import { DEFAULT_DOMAIN, getCurrentDomainCode, resolveCurrentDomain } from '@/utils/domainContext'
 
 const app = {
   state: {
@@ -29,6 +31,10 @@ const app = {
     color: '',
     weak: false,
     multiTab: true,
+    currentDomain: {
+      code: getCurrentDomainCode(),
+      text: DEFAULT_DOMAIN.text
+    },
     lang: 'zh-CN',
     _antLocale: {}
   },
@@ -80,6 +86,9 @@ const app = {
     [TOGGLE_MULTI_TAB]: (state, bool) => {
       storage.set(TOGGLE_MULTI_TAB, bool)
       state.multiTab = bool
+    },
+    [CURRENT_DOMAIN]: (state, domain) => {
+      state.currentDomain = resolveCurrentDomain([domain || DEFAULT_DOMAIN], domain && domain.code)
     }
   },
   actions: {
@@ -92,6 +101,9 @@ const app = {
           reject(e)
         })
       })
+    },
+    SetCurrentDomain ({ commit }, domain) {
+      commit(CURRENT_DOMAIN, domain)
     }
   }
 }

--- a/src/store/mutation-types.js
+++ b/src/store/mutation-types.js
@@ -12,6 +12,7 @@ export const TOGGLE_COLOR = 'color'
 export const TOGGLE_WEAK = 'weak'
 export const TOGGLE_MULTI_TAB = 'multi_tab'
 export const APP_LANGUAGE = 'app_language'
+export const CURRENT_DOMAIN = 'current_domain'
 
 export const CONTENT_WIDTH_TYPE = {
   Fluid: 'Fluid',

--- a/src/utils/domainContext.js
+++ b/src/utils/domainContext.js
@@ -1,0 +1,147 @@
+import storage from 'store'
+
+export const DOMAIN_STORAGE_KEY = 'ioeb_current_domain'
+export const DEFAULT_DOMAIN = {
+  code: 'aml',
+  text: '跨境支付AI监测'
+}
+
+const SINGLE_DOMAIN_MENU_PATHS = [
+  '/vertical-user',
+  '/vertical-scenario-dev',
+  '/vertical-ms',
+  '/vertical-meta-app'
+]
+
+export function normalizeDomains(domains = []) {
+  const normalized = domains
+    .map(item => ({
+      code: item && (item.code || item.value || item.text),
+      text: item && (item.text || item.label || item.code || item.value)
+    }))
+    .filter(item => item.code && item.text)
+
+  return normalized.length > 0 ? normalized : [DEFAULT_DOMAIN]
+}
+
+export function getCurrentDomainCode() {
+  return storage.get(DOMAIN_STORAGE_KEY) || DEFAULT_DOMAIN.code
+}
+
+export function setCurrentDomainCode(code) {
+  storage.set(DOMAIN_STORAGE_KEY, code || DEFAULT_DOMAIN.code)
+}
+
+export function resolveCurrentDomain(domains = [], preferredCode = getCurrentDomainCode()) {
+  const normalized = normalizeDomains(domains)
+  const matched = normalized.find(domain => domain.code === preferredCode) || normalized[0]
+  setCurrentDomainCode(matched.code)
+  return matched
+}
+
+export function getDomainModuleEntryPath(basePath, domainCode = getCurrentDomainCode(), permissionList = []) {
+  const code = domainCode || DEFAULT_DOMAIN.code
+  switch (basePath) {
+    case '/vertical-user':
+      return `/vertical-user/${code}`
+    case '/vertical-scenario-dev':
+      return `/vertical-scenario-dev/${code}`
+    case '/vertical-ms':
+      return `/vertical-ms/${code}`
+    case '/vertical-meta-app':
+      return `/vertical-atom-app/${code}`
+    case '/evaluation':
+      if (permissionList.includes('admin') || permissionList.includes('publisher')) {
+        return `/evaluation/${code}/technology`
+      }
+      return `/evaluation/${code}/emulation`
+    case '/operation':
+      if (permissionList.includes('publisher')) {
+        return `/operation/${code}/container-status`
+      }
+      if (permissionList.includes('admin')) {
+        return `/operation/${code}/container-manage`
+      }
+      return `/operation/${code}/container-status`
+    default:
+      return basePath
+  }
+}
+
+export function replaceDomainInPath(path, domainCode, permissionList = []) {
+  if (!path || !domainCode) {
+    return path
+  }
+
+  const rules = [
+    { pattern: /^\/vertical-user\/[^/]+/, replacement: `/vertical-user/${domainCode}` },
+    { pattern: /^\/vertical-scenario-dev\/[^/]+/, replacement: `/vertical-scenario-dev/${domainCode}` },
+    { pattern: /^\/vertical-ms\/[^/]+/, replacement: `/vertical-ms/${domainCode}` },
+    { pattern: /^\/vertical-atom-app\/[^/]+/, replacement: `/vertical-atom-app/${domainCode}` },
+    { pattern: /^\/evaluation\/[^/]+/, replacement: `/evaluation/${domainCode}` },
+    { pattern: /^\/operation\/[^/]+/, replacement: `/operation/${domainCode}` }
+  ]
+
+  for (const rule of rules) {
+    if (rule.pattern.test(path)) {
+      return path.replace(rule.pattern, rule.replacement)
+    }
+  }
+
+  const topLevelRule = [
+    '/vertical-user',
+    '/vertical-scenario-dev',
+    '/vertical-ms',
+    '/vertical-meta-app',
+    '/evaluation',
+    '/operation'
+  ].find(basePath => path === basePath)
+
+  return topLevelRule ? getDomainModuleEntryPath(topLevelRule, domainCode, permissionList) : path
+}
+
+export function isDomainRoutedPath(path) {
+  return [
+    /^\/vertical-user(\/|$)/,
+    /^\/vertical-scenario-dev(\/|$)/,
+    /^\/vertical-ms(\/|$)/,
+    /^\/vertical-atom-app(\/|$)/,
+    /^\/vertical-meta-app(\/|$)/,
+    /^\/evaluation(\/|$)/,
+    /^\/operation(\/|$)/
+  ].some(pattern => pattern.test(path || ''))
+}
+
+export function projectDomainMenus(menus = [], domainCode = getCurrentDomainCode(), permissionList = []) {
+  return menus.map(menu => {
+    if (!menu || !menu.path) {
+      return menu
+    }
+
+    if (SINGLE_DOMAIN_MENU_PATHS.includes(menu.path)) {
+      const entryPath = getDomainModuleEntryPath(menu.path, domainCode, permissionList)
+      const selectedDomainRoute = (menu.children || []).find(child => child.path === entryPath) || (menu.children || [])[0]
+      const projectedMenu = {
+        ...menu,
+        path: selectedDomainRoute ? selectedDomainRoute.path : entryPath,
+        name: selectedDomainRoute ? selectedDomainRoute.name : menu.name,
+        redirect: entryPath
+      }
+      delete projectedMenu.children
+      delete projectedMenu.hideChildrenInMenu
+      return projectedMenu
+    }
+
+    if (menu.path === '/evaluation' || menu.path === '/operation') {
+      const domainPath = `/${menu.path.split('/')[1]}/${domainCode}`
+      const selectedDomainRoute = (menu.children || []).find(child => child.path === domainPath) || (menu.children || [])[0]
+      return {
+        ...menu,
+        redirect: getDomainModuleEntryPath(menu.path, domainCode, permissionList),
+        children: selectedDomainRoute && selectedDomainRoute.children ? selectedDomainRoute.children : []
+      }
+    }
+
+    return menu
+  })
+}


### PR DESCRIPTION
## Summary
- Add a frontend current-domain context backed by local storage and Vuex.
- Add a top-right global vertical domain selector that uses the existing domain dictionary.
- Project the sidebar menu to the selected domain so users no longer see repeated domain lists under each primary module.
- Keep existing route/page components and `verticalType` props, preserving current resource filtering behavior.
- Make vertical-module redirects resolve from the selected domain at navigation time.
- Fix the existing duplicated route name on `/vertical-meta-app` so the projected menu routes to the meta-app module correctly.

## Scope
- Frontend-only first phase of domain isolation.
- No registration questionnaire or backend persistence added in this PR.
- No backend/API changes required.

## Validation
- PASS: `./node_modules/.bin/eslint src/utils/domainContext.js src/components/GlobalHeader/DomainSelector.vue src/components/GlobalHeader/RightContent.vue src/layouts/BasicLayout.vue src/permission.js src/config/router.config.js src/store/modules/app.js src/store/getters.js src/store/mutation-types.js`
- PASS: `git diff --check`
- PASS: `npm run build` (existing bundle-size warnings only)

Fixes #105