### PR TITLE
Show user action records in user management

### DIFF
--- a/src/api/audit.js
+++ b/src/api/audit.js
@@ -1,0 +1,11 @@
+import request from '@/utils/request'
+
+const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
+
+export function getUserActionLogs(params) {
+  return request({
+    url: `${API_BASE_URL}/audit/action-logs`,
+    method: 'get',
+    params
+  })
+}

--- a/src/components/UserActionLogModal.vue
+++ b/src/components/UserActionLogModal.vue
@@ -1,0 +1,264 @@
+<template>
+  <a-modal
+    :visible="visible"
+    :title="modalTitle"
+    width="980px"
+    :footer="null"
+    @cancel="handleClose"
+  >
+    <div class="action-log-toolbar">
+      <a-select
+        v-model="queryParam.actionType"
+        allowClear
+        placeholder="行为类型"
+        style="width: 180px"
+        @change="handleFilterChange"
+      >
+        <a-select-option
+          v-for="option in actionTypeOptions"
+          :key="option.value"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </a-select-option>
+      </a-select>
+      <a-button icon="reload" :loading="loading" @click="loadLogs">
+        刷新
+      </a-button>
+    </div>
+
+    <a-table
+      size="small"
+      rowKey="id"
+      :columns="columns"
+      :dataSource="logs"
+      :loading="loading"
+      :pagination="pagination"
+      @change="handleTableChange"
+    >
+      <span slot="actionType" slot-scope="text">
+        {{ getActionTypeLabel(text) }}
+      </span>
+      <span slot="request" slot-scope="text, record">
+        <a-tag color="blue">{{ record.method }}</a-tag>
+        <span class="request-path">{{ record.path }}</span>
+      </span>
+      <span slot="statusCode" slot-scope="text">
+        <a-badge :status="getStatusBadge(text)" :text="String(text)" />
+      </span>
+      <span slot="userAgent" slot-scope="text">
+        <a-tooltip :title="text || '-'">
+          <span class="user-agent">{{ text || '-' }}</span>
+        </a-tooltip>
+      </span>
+      <span slot="createdAt" slot-scope="text">
+        {{ formatTime(text) }}
+      </span>
+    </a-table>
+  </a-modal>
+</template>
+
+<script>
+import { getUserActionLogs } from '@/api/audit'
+
+const ACTION_TYPE_OPTIONS = [
+  { value: 'auth.login', label: '登录' },
+  { value: 'auth.logout', label: '登出' },
+  { value: 'auth.register', label: '注册' },
+  { value: 'auth.info', label: '获取用户信息' },
+  { value: 'users.list', label: '查看用户列表' },
+  { value: 'users.create', label: '创建用户' },
+  { value: 'users.update', label: '更新用户' },
+  { value: 'users.delete', label: '删除用户' },
+  { value: 'users.status', label: '切换用户状态' },
+  { value: 'users.role', label: '切换用户角色' },
+  { value: 'users.password', label: '修改用户密码' },
+  { value: 'services.request', label: '服务操作' },
+  { value: 'services.publish', label: '服务发布' },
+  { value: 'services.deploy', label: '服务部署' },
+  { value: 'services.stop', label: '服务停止' },
+  { value: 'services.delete', label: '服务删除' },
+  { value: 'datasets.request', label: '数据集操作' }
+]
+
+export default {
+  name: 'UserActionLogModal',
+  data () {
+    return {
+      visible: false,
+      loading: false,
+      currentUser: null,
+      logs: [],
+      queryParam: {
+        actionType: undefined
+      },
+      pagination: {
+        current: 1,
+        pageSize: 10,
+        total: 0,
+        showSizeChanger: true,
+        showQuickJumper: true,
+        showTotal: total => `共 ${total} 条记录`
+      },
+      actionTypeOptions: ACTION_TYPE_OPTIONS,
+      columns: [
+        {
+          title: '行为类型',
+          dataIndex: 'actionType',
+          width: '130px',
+          scopedSlots: { customRender: 'actionType' }
+        },
+        {
+          title: '请求',
+          dataIndex: 'path',
+          scopedSlots: { customRender: 'request' }
+        },
+        {
+          title: '状态',
+          dataIndex: 'statusCode',
+          width: '80px',
+          scopedSlots: { customRender: 'statusCode' }
+        },
+        {
+          title: '客户端IP',
+          dataIndex: 'clientIp',
+          width: '140px'
+        },
+        {
+          title: 'User-Agent',
+          dataIndex: 'userAgent',
+          width: '180px',
+          scopedSlots: { customRender: 'userAgent' }
+        },
+        {
+          title: '时间',
+          dataIndex: 'createdAt',
+          width: '180px',
+          scopedSlots: { customRender: 'createdAt' }
+        }
+      ]
+    }
+  },
+  computed: {
+    modalTitle () {
+      if (!this.currentUser) {
+        return '用户行为记录'
+      }
+      return `${this.currentUser.name} 的行为记录`
+    }
+  },
+  methods: {
+    show (user) {
+      this.currentUser = user
+      this.visible = true
+      this.logs = []
+      this.queryParam = {
+        actionType: undefined
+      }
+      this.pagination = {
+        ...this.pagination,
+        current: 1,
+        total: 0
+      }
+      this.loadLogs()
+    },
+    async loadLogs () {
+      if (!this.currentUser) {
+        return
+      }
+      this.loading = true
+      try {
+        const response = await getUserActionLogs({
+          userId: this.currentUser.id,
+          actionType: this.queryParam.actionType,
+          page: this.pagination.current,
+          pageSize: this.pagination.pageSize
+        })
+        if (response.status === 'success') {
+          this.logs = response.logs || []
+          const pagination = response.pagination || {}
+          this.pagination = {
+            ...this.pagination,
+            current: pagination.page || this.pagination.current,
+            pageSize: pagination.pageSize || this.pagination.pageSize,
+            total: pagination.total || 0
+          }
+        } else {
+          this.$message.error('获取行为记录失败')
+        }
+      } catch (error) {
+        console.error('获取行为记录出错:', error)
+        this.$message.error('获取行为记录失败')
+      } finally {
+        this.loading = false
+      }
+    },
+    handleFilterChange () {
+      this.pagination = {
+        ...this.pagination,
+        current: 1
+      }
+      this.loadLogs()
+    },
+    handleTableChange (pagination) {
+      this.pagination = {
+        ...this.pagination,
+        current: pagination.current,
+        pageSize: pagination.pageSize
+      }
+      this.loadLogs()
+    },
+    handleClose () {
+      this.visible = false
+    },
+    formatTime (timestamp) {
+      if (!timestamp) {
+        return '-'
+      }
+      return new Date(timestamp).toLocaleString('zh-CN')
+    },
+    getStatusBadge (statusCode) {
+      if (statusCode >= 500) {
+        return 'error'
+      }
+      if (statusCode >= 400) {
+        return 'warning'
+      }
+      if (statusCode >= 300) {
+        return 'processing'
+      }
+      return 'success'
+    },
+    getActionTypeLabel (actionType) {
+      const option = ACTION_TYPE_OPTIONS.find(item => item.value === actionType)
+      return option ? option.label : actionType
+    }
+  }
+}
+</script>
+
+<style lang="less" scoped>
+.action-log-toolbar {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.request-path,
+.user-agent {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.request-path {
+  max-width: 420px;
+}
+
+.user-agent {
+  max-width: 160px;
+}
+</style>

--- a/src/views/user-manage/index.vue
+++ b/src/views/user-manage/index.vue
@@ -69,6 +69,8 @@
             <a-button style="padding: 0" type="link" v-if="record.status === 0" :disabled="record.username === 'root'" size="small" @click="handleActivate(record)">激活</a-button>
             <a-button style="padding: 0" type="link" v-if="record.status === 1" :disabled="record.username === 'root'" size="small" @click="handleDisable(record)">禁用</a-button>
             <a-divider type="vertical" />
+            <a-button style="padding: 0" type="link" size="small" @click="handleViewActionLogs(record)">行为</a-button>
+            <a-divider type="vertical" />
             <a-button v-if="record.username === 'root'" style="padding: 0" type="link" disabled size="small" @click="handleDelete(record)">删除</a-button>
             <a-button v-else style="padding: 0;color: orangered" type="link" size="small" @click="handleDelete(record)">删除</a-button>
           </template>
@@ -81,11 +83,13 @@
       ref="userManageModal"
       @refresh="handleModalRefresh"
     />
+    <UserActionLogModal ref="userActionLogModal" />
   </page-header-wrapper>
 </template>
 
 <script>
 import { getAllUsers, enableUser, disableUser, deleteUser, getAllRoles } from '@/api/users'
+import UserActionLogModal from '@/components/UserActionLogModal'
 import UserManageModal from '@/components/UserManageModal'
 
 const statusMap = {
@@ -102,6 +106,7 @@ const statusMap = {
 export default {
   name: 'TableList',
   components: {
+    UserActionLogModal,
     UserManageModal
   },
   data () {
@@ -161,7 +166,7 @@ export default {
         {
           title: '操作',
           dataIndex: 'action',
-          width: '110px',
+          width: '170px',
           align: 'center',
           scopedSlots: { customRender: 'action' }
         }
@@ -344,6 +349,9 @@ export default {
     },
     handleRoleEdit(record) {
       this.$refs.userManageModal.showRoleSelectModal(record)
+    },
+    handleViewActionLogs(record) {
+      this.$refs.userActionLogModal.show(record)
     },
     getRoleName(roleId) {
       // 如果UserManageModal组件已经加载，使用其getRoleName方法


### PR DESCRIPTION
## Summary
- Add an audit API client for `GET /api/audit/action-logs`.
- Add a user action log modal for the admin user management page.
- Add a `行为` action to each user row.
- Display action type, request method/path, status, client IP, User-Agent, and timestamp with pagination and action-type filtering.

## Dependency
- Depends on backend API PR: fdueblab/ioeb_backend#63

## Validation
- PASS: `./node_modules/.bin/eslint src/api/audit.js src/components/UserActionLogModal.vue src/views/user-manage/index.vue`
- PASS: `git diff --check`
- PASS: `npm run build` (existing bundle-size warnings only)

Fixes #107