### PR TITLE
Change default post-login landing page

### DIFF
--- a/src/config/router.config.js
+++ b/src/config/router.config.js
@@ -2,6 +2,7 @@
 import { UserLayout, BasicLayout, BlankLayout, AppView } from '@/layouts'
 import { bxAnaalyse } from '@/core/icons'
 import { loadDict } from '@/utils/dictionaryCache'
+import { getDefaultLandingPath } from '@/utils/domainContext'
 
 const RouteView = {
   name: 'RouteView',
@@ -499,9 +500,7 @@ export const asyncRouterMap = [
     name: 'index',
     component: BasicLayout,
     meta: { title: 'menu.home' },
-    redirect: {
-      name: 'home'
-    },
+    redirect: () => getDefaultLandingPath(),
     children: [
       // 垂域应用AI资源检索 - 从字典动态获取
       {

--- a/src/permission.js
+++ b/src/permission.js
@@ -9,6 +9,7 @@ import { ACCESS_TOKEN } from '@/store/mutation-types'
 import { i18nRender } from '@/locales'
 import { loadDict, preloadAllDict } from '@/utils/dictionaryCache' // 引入字典预加载功能
 import {
+  getDefaultLandingPath,
   getCurrentDomainCode,
   getDomainModuleEntryPath,
   resolveCurrentDomain
@@ -27,7 +28,7 @@ NProgress.configure({ showSpinner: false }) // NProgress Configuration
 
 const allowList = ['login', 'register', 'registerResult'] // no redirect allowList
 const loginRoutePath = '/user/login'
-const defaultRoutePath = '/home'
+const getDefaultRoutePath = () => getDefaultLandingPath()
 
 router.beforeEach(async (to, from, next) => {
   NProgress.start() // start progress bar
@@ -36,7 +37,7 @@ router.beforeEach(async (to, from, next) => {
   const token = storage.get(ACCESS_TOKEN)
   if (token) {
     if (to.path === loginRoutePath) {
-      next({ path: defaultRoutePath })
+      next({ path: getDefaultRoutePath() })
       NProgress.done()
     } else {
       // check login user.roles is null

--- a/src/router/generator-routers.js
+++ b/src/router/generator-routers.js
@@ -2,6 +2,7 @@
 import * as loginService from '@/api/login'
 // eslint-disable-next-line
 import { BasicLayout, BlankLayout, PageView, RouteView } from '@/layouts'
+import { getDefaultLandingPath } from '@/utils/domainContext'
 
 // 前端路由表 (基于动态)
 const constantRouterComponents = {
@@ -68,7 +69,7 @@ const rootRouter = {
   name: 'index',
   path: '',
   component: 'BasicLayout',
-  redirect: '/dashboard',
+  redirect: () => getDefaultLandingPath(),
   meta: {
     title: '首页'
   },

--- a/src/utils/domainContext.js
+++ b/src/utils/domainContext.js
@@ -68,6 +68,10 @@ export function getDomainModuleEntryPath(basePath, domainCode = getCurrentDomain
   }
 }
 
+export function getDefaultLandingPath(domainCode = getCurrentDomainCode()) {
+  return getDomainModuleEntryPath('/vertical-user', domainCode)
+}
+
 export function replaceDomainInPath(path, domainCode, permissionList = []) {
   if (!path || !domainCode) {
     return path


### PR DESCRIPTION
## Summary
- change the default authenticated landing route from the data statistics page to the current domain's AI resource search entry
- keep deep-link login redirects and direct access to the data statistics page working
- reuse the same default landing helper across static and dynamic router paths

## Validation
- ./node_modules/.bin/eslint src/utils/domainContext.js src/permission.js src/config/router.config.js src/router/generator-routers.js
- npm run build

Closes #109