### PR TITLE
Use fuzzy vertical resource search

### DIFF
--- a/src/views/vertical/user/GenericVerticalList.vue
+++ b/src/views/vertical/user/GenericVerticalList.vue
@@ -4,8 +4,15 @@
     <search-form
       :is-dev="isDev"
       :method-type-options="methodTypeOptions"
+      :services="dataSource"
+      :attribute-arr="attributeArr"
+      :type-arr="typeArr"
+      :industry-arr="industryArr"
+      :scenario-arr="scenarioArr"
+      :technology-arr="technologyArr"
       :vertical-type="verticalType"
       @search-completed="handleSearchCompleted"
+      @search-reset="handleSearchReset"
     />
 
     <!-- 筛选标签部分 -->
@@ -179,14 +186,13 @@ export default {
     },
     // 筛选变化处理 - 从FilterCard组件接收
     handleFilterChange(filterValues) {
+      this.agentSearchData = []
       this.filterDataSource(filterValues)
     },
     // 处理搜索结果 - 从SearchForm组件接收
     handleSearchCompleted(searchResults) {
       this.agentSearchData = searchResults
-      this.filteredDataSource = this.dataSource.filter(item =>
-        searchResults.includes(item.name)
-      )
+      this.filteredDataSource = searchResults
 
       this.$nextTick(() => {
         this.$message.success('检索完毕！')
@@ -196,6 +202,10 @@ export default {
           table.scrollIntoView({ behavior: 'smooth' })
         }
       })
+    },
+    handleSearchReset() {
+      this.agentSearchData = []
+      this.filteredDataSource = this.dataSource
     },
     // 根据筛选条件过滤数据
     async filterDataSource(filterValues) {

--- a/src/views/vertical/user/components/SearchForm.vue
+++ b/src/views/vertical/user/components/SearchForm.vue
@@ -74,14 +74,36 @@
 </template>
 
 <script>
-import request from '@/utils/request'
-
 export default {
   name: 'SearchForm',
   props: {
     verticalType: {
       type: String,
       required: true
+    },
+    services: {
+      type: Array,
+      default: () => []
+    },
+    attributeArr: {
+      type: Array,
+      default: () => []
+    },
+    typeArr: {
+      type: Array,
+      default: () => []
+    },
+    industryArr: {
+      type: Array,
+      default: () => []
+    },
+    scenarioArr: {
+      type: Array,
+      default: () => []
+    },
+    technologyArr: {
+      type: Array,
+      default: () => []
     }
   },
   data() {
@@ -137,6 +159,7 @@ export default {
         function: '',
         requirement: ''
       }
+      this.$emit('search-reset')
     },
 
     async handleSearch() {
@@ -152,16 +175,7 @@ export default {
         }
 
         try {
-          this.apiResult = await request({
-            url: this.apiUrl,
-            method: 'POST',
-            data: this.form,
-            headers: this.apiHeader
-          })
-
-          console.log(this.apiResult)
-          // 通知父组件搜索结果
-          const searchResults = this.apiResult.data.services
+          const searchResults = this.fuzzySearchServices(this.form)
           this.$emit('search-completed', searchResults)
         } catch (error) {
           console.error('智能检索请求失败:', error)
@@ -172,6 +186,111 @@ export default {
       } else {
         this.$message.error('请先输入您的需求！')
       }
+    },
+    fuzzySearchServices(form) {
+      const terms = this.getSearchTerms(form)
+      if (terms.length === 0) {
+        return []
+      }
+
+      return (this.services || [])
+        .map(service => ({
+          service,
+          score: this.getServiceSearchScore(service, terms)
+        }))
+        .filter(item => item.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map(item => item.service)
+    },
+    getSearchTerms(form) {
+      return Object.keys(form)
+        .map(key => form[key])
+        .join(' ')
+        .split(/[\s,，;；、。.!！?？/\\|]+/)
+        .map(term => this.normalizeText(term))
+        .filter(Boolean)
+    },
+    getServiceSearchScore(service, terms) {
+      const searchableText = this.buildServiceSearchText(service)
+      if (!terms.every(term => searchableText.all.includes(term))) {
+        return 0
+      }
+
+      return terms.reduce((score, term) => {
+        if (searchableText.name.includes(term)) {
+          score += 8
+        }
+        if (searchableText.description.includes(term)) {
+          score += 5
+        }
+        if (searchableText.metadata.includes(term)) {
+          score += 3
+        }
+        return score + 1
+      }, 0)
+    },
+    buildServiceSearchText(service) {
+      const attributeText = this.getDictText(this.attributeArr, service.attribute)
+      const typeText = this.getDictText(this.typeArr, service.type)
+      const industryText = this.getDictText(this.industryArr, service.industry)
+      const scenarioText = this.getDictText(this.scenarioArr, service.scenario)
+      const technologyText = this.getDictText(this.technologyArr, service.technology)
+      const apiListText = this.valueToText(service.apiList)
+      const sourceText = this.valueToText(service.source)
+
+      const name = this.normalizeText(service.name)
+      const description = this.normalizeText([
+        service.description,
+        service.des,
+        service.role,
+        service.function,
+        service.requirement,
+        service.msIntroduce,
+        sourceText
+      ].join(' '))
+      const metadata = this.normalizeText([
+        attributeText,
+        typeText,
+        industryText,
+        scenarioText,
+        technologyText,
+        apiListText,
+        service.status
+      ].join(' '))
+
+      return {
+        name,
+        description,
+        metadata,
+        all: [name, description, metadata].join(' ')
+      }
+    },
+    getDictText(options, value) {
+      const values = Array.isArray(value)
+        ? value
+        : String(value || '').split(',').map(item => item.trim()).filter(Boolean)
+
+      return values
+        .map(item => {
+          const matched = (options || []).find(option => option.code === item || option.value === item)
+          return matched ? `${matched.text || matched.label || ''} ${item}` : item
+        })
+        .join(' ')
+    },
+    valueToText(value) {
+      if (!value) {
+        return ''
+      }
+      if (Array.isArray(value)) {
+        return value.map(item => this.valueToText(item)).join(' ')
+      }
+      if (typeof value === 'object') {
+        return Object.keys(value).map(key => this.valueToText(value[key])).join(' ')
+      }
+      return String(value)
+    },
+    normalizeText(value) {
+      return String(value || '').trim().toLowerCase()
     },
 
     // 显示/隐藏知识增强输入框


### PR DESCRIPTION
## Summary
- switch the vertical resource search implementation from the unavailable external agent request to local fuzzy matching over the current domain's loaded resources
- keep the existing user-facing copy and result flow unchanged
- search across service names, descriptions, source details, API metadata, and dictionary-backed fields
- reset search results back to the current domain resource list when the input reset action is used

## Validation
- ./node_modules/.bin/eslint src/views/vertical/user/GenericVerticalList.vue src/views/vertical/user/components/SearchForm.vue
- npm run build

Closes #111