### PR TITLE
fix: resolve API base URL at runtime

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 NODE_ENV=production
-VUE_APP_HOST=fdueblab.cn
+VUE_APP_HOST=
 VUE_APP_PREVIEW = false
 # VUE_APP_API_BASE_URL = 'https://torna.kxyun.net/mock/msa/api'
-VUE_APP_API_BASE_URL = 'https://fdueblab.cn/api'
-VUE_APP_AGENT_BASE_URL = 'https://fdueblab.cn'
+VUE_APP_API_BASE_URL = '/api'
+VUE_APP_AGENT_BASE_URL = ''
 # VUE_APP_AGENT_BASE_URL = 'http://localhost:8010'

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 NODE_ENV = development
 VUE_APP_PREVIEW = true
-VUE_APP_API_BASE_URL = 'https://fdueblab.cn/api'
-VUE_APP_AGENT_BASE_URL = 'http://localhost:8010'
+VUE_APP_API_BASE_URL = '/api'
+VUE_APP_AGENT_BASE_URL = ''

--- a/src/api/audit.js
+++ b/src/api/audit.js
@@ -1,6 +1,5 @@
 import request from '@/utils/request'
-
-const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
+import { API_BASE_URL } from '@/utils/baseUrl'
 
 export function getUserActionLogs(params) {
   return request({

--- a/src/api/dictionary.js
+++ b/src/api/dictionary.js
@@ -1,6 +1,5 @@
 import request from '@/utils/request'
-
-const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
+import { API_BASE_URL } from '@/utils/baseUrl'
 
 /**
  * 获取指定类别的字典列表

--- a/src/api/evaluation.js
+++ b/src/api/evaluation.js
@@ -1,7 +1,5 @@
 import request from '@/utils/request'
-
-const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
-const AGENT_BASE_URL = process.env.VUE_APP_AGENT_BASE_URL || 'https://fdueblab.cn'
+import { API_BASE_URL, AGENT_BASE_URL } from '@/utils/baseUrl'
 
 /**
  * AI分析评测数据

--- a/src/api/service.js
+++ b/src/api/service.js
@@ -1,6 +1,5 @@
 import request from '@/utils/request'
-
-const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
+import { API_BASE_URL } from '@/utils/baseUrl'
 
 /**
  * 获取所有微服务

--- a/src/api/simulation_builder.js
+++ b/src/api/simulation_builder.js
@@ -9,11 +9,11 @@
  * `fetchSimulationRecords` / `compareSimulationRecords` 须传入同一上下文的 `appName`（与 prop 一致）。
  */
 import request from '@/utils/request'
+import { AGENT_BASE_URL } from '@/utils/baseUrl'
 import { simulationBuildInMemory } from '@/mock/services/simulation_builder_inmemory'
 import { useMemorySimulation } from '@/mock/data/meta_apps_data'
 
-const SIMULATION_BASE_URL =
-  process.env.VUE_APP_AGENT_BASE_URL || process.env.VUE_APP_API_BASE_URL || ''
+const SIMULATION_BASE_URL = AGENT_BASE_URL
 
 /** SSE 自定义事件名（与后端约定一致） */
 const SIMULATION_SSE_EVENTS = [

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,6 +1,5 @@
 import request from '@/utils/request'
-
-const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
+import { API_BASE_URL } from '@/utils/baseUrl'
 
 /**
  * 获取所有用户

--- a/src/utils/baseUrl.js
+++ b/src/utils/baseUrl.js
@@ -1,0 +1,30 @@
+const trimTrailingSlash = (value) => value.replace(/\/+$/, '')
+
+const normalizePath = (path) => {
+  const normalized = (path || '').trim().replace(/^\/+|\/+$/g, '')
+  return normalized ? `/${normalized}` : ''
+}
+
+export const resolveRuntimeBaseUrl = (configuredValue, fallbackPath = '') => {
+  const configured = (configuredValue || '').trim()
+  const fallback = normalizePath(fallbackPath)
+  const origin = typeof window !== 'undefined' && window.location ? window.location.origin : ''
+
+  if (!configured) {
+    return origin ? `${origin}${fallback}` : fallback
+  }
+
+  if (configured.startsWith('/')) {
+    return origin ? `${origin}${trimTrailingSlash(configured)}` : trimTrailingSlash(configured)
+  }
+
+  return trimTrailingSlash(configured)
+}
+
+export const API_BASE_URL = resolveRuntimeBaseUrl(process.env.VUE_APP_API_BASE_URL, '/api')
+export const AGENT_BASE_URL = resolveRuntimeBaseUrl(process.env.VUE_APP_AGENT_BASE_URL, '')
+
+export const buildServiceApiUrl = (serviceUrl) => {
+  const normalizedServiceUrl = String(serviceUrl || '').replace(/^\/+/, '')
+  return `${API_BASE_URL}/${normalizedServiceUrl}`
+}

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -4,17 +4,16 @@ import storage from 'store'
 import notification from 'ant-design-vue/es/notification'
 import { VueAxios } from './axios'
 import { ACCESS_TOKEN } from '@/store/mutation-types'
+import { API_BASE_URL, AGENT_BASE_URL } from '@/utils/baseUrl'
 
 /* eslint-disable handle-callback-err */
-// 添加Agent基础URL配置
-const AGENT_BASE_URL = process.env.VUE_APP_AGENT_BASE_URL || 'https://fdueblab.cn'
 console.log('AGENT_BASE_URL', AGENT_BASE_URL)
 
 // 创建 axios 实例
-console.log('process.env.VUE_APP_API_BASE_URL', process.env.VUE_APP_API_BASE_URL)
+console.log('API_BASE_URL', API_BASE_URL)
 const request = axios.create({
   // API 请求的默认前缀
-  baseURL: process.env.VUE_APP_API_BASE_URL,
+  baseURL: API_BASE_URL,
   timeout: 10000 // 请求超时时间
 })
 

--- a/src/views/vertical/user/GenericVerticalDomain.vue
+++ b/src/views/vertical/user/GenericVerticalDomain.vue
@@ -18,6 +18,7 @@ import UseService from './useService'
 import UseMetaApp from './useMetaApp'
 import UseMCP from './useMCP'
 import request from '@/utils/request'
+import { API_BASE_URL } from '@/utils/baseUrl'
 
 export default {
   name: 'GenericVerticalDomain',
@@ -87,7 +88,6 @@ export default {
       }
     },
     async downloadScenarioGeneratedAlgorithm(record) {
-      const API_BASE_URL = process.env.VUE_APP_API_BASE_URL
       const id = record && record.id
       if (!id) {
         this.$message.error('服务 ID 缺失')

--- a/src/views/vertical/user/useService.vue
+++ b/src/views/vertical/user/useService.vue
@@ -88,6 +88,7 @@
 
 <script>
 import request from '@/utils/request'
+import { buildServiceApiUrl } from '@/utils/baseUrl'
 import { codemirror } from 'vue-codemirror'
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/addon/lint/lint'
@@ -321,19 +322,7 @@ export default {
             break
         }
         // url地址
-        let url
-        switch (process.env.VUE_APP_HOST) {
-          case 'fdueblab.cn':
-            url = `https://fdueblab.cn/api/${this.serviceUrl}`
-            break
-          case 'ums':
-            // todo: 银联使用需要获取本机ipv4地址和服务对应端口
-            // eslint-disable-next-line no-fallthrough
-            url = `http://131.252.10.118/api/${this.serviceUrl}`
-            break
-          default:
-            url = `http://${process.env.VUE_APP_HOST}/api/${this.serviceUrl}`
-        }
+        const url = buildServiceApiUrl(this.serviceUrl)
         // 文件类型
         if (this.responseType === 2) {
           const response = await request({


### PR DESCRIPTION
## Summary
- replace hardcoded production API/agent base URLs with runtime origin-based URL resolution
- use the same frontend image safely across dev/staging and production
- update API modules and service invocation paths that previously read VUE_APP_API_BASE_URL or VUE_APP_HOST directly

## Root cause
The frontend production build embedded https://fdueblab.cn/api. When the same image was deployed to dev.fdueblab.cn, the dev UI still called the production backend, so audit logs and user actions appeared shared even though backend containers were connected to separate databases.

## Validation
- npm run build
- git diff --check
- verified source and dist no longer contain https://fdueblab.cn/api