### PR TITLE
[codex] Decouple service releases from platform releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     env:
       IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs
@@ -59,7 +60,7 @@ jobs:
   deploy-production:
     name: Deploy Production
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     env:
       IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-docs

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build & Push Frontend Image
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v'))
     runs-on: ubuntu-latest
     env:
       IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend
@@ -67,7 +67,7 @@ jobs:
   deploy-production:
     name: Deploy Production
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     env:
       IMAGE_REPO: ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-frontend

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-project1:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'services-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project1:${IMAGE_TAG}
 
   build-project2:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'services-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project2:${IMAGE_TAG}
 
   build-project3:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'services-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project3:${IMAGE_TAG}
 
   build-project4:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'services-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,6 +72,7 @@ jobs:
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ioeb-project4:${IMAGE_TAG}
 
   build-linezolid:
+    if: github.event_name == 'push' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'services-v'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +114,7 @@ jobs:
   deploy-production:
     name: Deploy Production Services
     needs: [build-project1, build-project2, build-project3, build-project4, build-linezolid]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'services-v')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/api/Project-4/Dockerfile
+++ b/api/Project-4/Dockerfile
@@ -14,14 +14,8 @@ WORKDIR /app
 # 复制依赖文件
 COPY requirements.txt .
 
-# 先删除 requirements.txt 中的 dgl（如果有的话）
-RUN sed -i '/^dgl/d' requirements.txt
-
-# 安装其他 Python 依赖
-RUN pip install --no-cache-dir -r requirements.txt
-
-# 单独安装 DGL
-RUN pip install --no-cache-dir dgl -f https://data.dgl.ai/wheels/torch-2.3/repo.html
+# 安装 Python 依赖，DGL 从 PyTorch 2.3 专用 wheel 源安装
+RUN pip install --no-cache-dir -r requirements.txt -f https://data.dgl.ai/wheels/torch-2.3/repo.html
 
 # 复制应用代码
 COPY . .

--- a/api/Project_1/Dockerfile
+++ b/api/Project_1/Dockerfile
@@ -14,14 +14,8 @@ WORKDIR /app
 # 复制依赖文件
 COPY requirements.txt .
 
-# 先删除 requirements.txt 中的 dgl（如果有的话）
-RUN sed -i '/^dgl/d' requirements.txt
-
-# 安装其他 Python 依赖
-RUN pip install -r requirements.txt
-
-# 单独安装 DGL
-RUN pip install dgl -f https://data.dgl.ai/wheels/torch-2.3/repo.html
+# 安装 Python 依赖，DGL 从 PyTorch 2.3 专用 wheel 源安装
+RUN pip install -r requirements.txt -f https://data.dgl.ai/wheels/torch-2.3/repo.html
 
 # 复制应用代码
 COPY . .

--- a/api/Project_1/requirements.txt
+++ b/api/Project_1/requirements.txt
@@ -3,7 +3,7 @@ flask-restx==1.3.0
 flask_cors
 torch==2.3.0
 torchdata==0.9.0
-dgl
+dgl==2.3.0
 numpy==1.26.3
 pandas==2.2.2
 werkzeug==3.1.3 

--- a/api/Project_2/Dockerfile
+++ b/api/Project_2/Dockerfile
@@ -14,14 +14,8 @@ WORKDIR /app
 # 复制依赖文件
 COPY requirements.txt .
 
-# 先删除 requirements.txt 中的 dgl（如果有的话）
-RUN sed -i '/^dgl/d' requirements.txt
-
-# 安装其他 Python 依赖
-RUN pip install  -r requirements.txt
-
-# 单独安装 DGL
-RUN pip install dgl -f https://data.dgl.ai/wheels/torch-2.3/repo.html
+# 安装 Python 依赖，DGL 从 PyTorch 2.3 专用 wheel 源安装
+RUN pip install -r requirements.txt -f https://data.dgl.ai/wheels/torch-2.3/repo.html
 
 # 复制应用代码
 COPY . .

--- a/api/Project_2/requirements.txt
+++ b/api/Project_2/requirements.txt
@@ -3,7 +3,7 @@ flask-restx==1.3.0
 flask_cors
 torch==2.3.0
 torchdata==0.9.0
-dgl
+dgl==2.3.0
 numpy==1.26.3
 pandas==2.2.2
 werkzeug==3.1.3 

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -33,7 +33,7 @@ v2026.06.24.1
 | --- | --- | --- |
 | 后端 | `fdueblab/ioeb_backend` | `backend` |
 | 智能体 | `fdueblab/Micro-Agent` | `agent` |
-| 前端与平台服务 | `fdueblab/ioeb` | `frontend`、`docs`、`linezolid`、`project-1` 到 `project-4` |
+| 前端与文档 | `fdueblab/ioeb` | `frontend`、`docs` |
 
 推荐发布顺序：
 
@@ -80,6 +80,18 @@ python3 scripts/create-platform-release.py release/platform-release.v2026.06.24.
 ```bash
 python3 scripts/create-platform-release.py release/platform-release.v2026.06.24.json --execute --skip-existing
 ```
+
+## 服务镜像发布
+
+`linezolid` 和 `project-1` 到 `project-4` 不随每周平台发布自动部署，避免某个科研服务镜像构建失败阻塞核心平台上线。
+
+这些服务需要单独发布时，在 `fdueblab/ioeb` 创建 `services-vYYYY.MM.DD` 或 `services-vYYYY.MM.DD.N` 格式的 GitHub Release。只有这个前缀会触发 `Build & Deploy Services` 的生产部署；前端和文档 workflow 只响应 `v*` 平台版本，不会被服务版本误触发。
+
+服务发布前需要额外确认：
+
+- 需要发布的服务镜像在开发测试环境或本地构建通过。
+- 该服务依赖的数据、模型文件和端口配置已在生产环境准备好。
+- 如果只需要发布前端、后端、文档或智能体，不要创建 `services-v*` release。
 
 ## 发布前检查
 

--- a/release/platform-release.example.json
+++ b/release/platform-release.example.json
@@ -21,8 +21,8 @@
       "name": "frontend",
       "repo": "fdueblab/ioeb",
       "ref": "master",
-      "deploys": ["frontend", "docs", "linezolid", "project-1", "project-2", "project-3", "project-4"],
-      "releaseWorkflows": ["CI", "Build & Deploy Docs", "Build & Deploy Services"]
+      "deploys": ["frontend", "docs"],
+      "releaseWorkflows": ["CI", "Build & Deploy Docs"]
     }
   ],
   "checks": [

--- a/scripts/create-platform-release.py
+++ b/scripts/create-platform-release.py
@@ -31,7 +31,7 @@ DEFAULT_RELEASE_ORDER = ["backend", "agent", "frontend"]
 DEFAULT_WORKFLOWS = {
     "fdueblab/ioeb_backend": ["CI"],
     "fdueblab/Micro-Agent": ["CI"],
-    "fdueblab/ioeb": ["CI", "Build & Deploy Docs", "Build & Deploy Services"],
+    "fdueblab/ioeb": ["CI", "Build & Deploy Docs"],
 }
 
 
@@ -49,12 +49,24 @@ def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[st
     return proc
 
 
-def gh_json(args: list[str]) -> Any:
-    proc = run(["gh", *args])
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise ReleaseError(f"gh did not return JSON for args {args}: {proc.stdout}") from exc
+def gh_json(args: list[str], *, attempts: int = 3) -> Any:
+    last_error = ""
+    for attempt in range(1, attempts + 1):
+        proc = run(["gh", *args], check=False)
+        if proc.returncode == 0:
+            try:
+                return json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                last_error = f"gh did not return JSON for args {args}: {proc.stdout}"
+        else:
+            rendered = " ".join(shlex.quote(part) for part in ["gh", *args])
+            last_error = (
+                f"Command failed: {rendered}\n"
+                f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+            )
+        if attempt < attempts:
+            time.sleep(min(2 ** (attempt - 1), 5))
+    raise ReleaseError(last_error)
 
 
 def load_manifest(path: str) -> dict[str, Any]:


### PR DESCRIPTION
## What changed

- Limit platform releases (`v*`) to frontend and docs workflows in `fdueblab/ioeb`.
- Limit service image releases to `services-v*` tags in `Build & Deploy Services`.
- Remove `Build & Deploy Services` from the platform release script defaults and manifest example.
- Document the separate service image release flow.
- Pin DGL installation for project services so future service builds do not resolve to the currently inaccessible `dgl 2.5.0` wheel.
- Add retry handling around GitHub CLI JSON calls in the release script.

## Why

The first production release completed for backend, agent, docs, and frontend, but the `Build & Deploy Services` workflow failed because project service Docker builds resolved unpinned DGL to `2.5.0`, whose wheel URL currently returns 403. That failure should not block core platform releases.

Going forward:

- Weekly platform release: create `vYYYY.MM.DD` releases through `scripts/create-platform-release.py`.
- Service image release: create a separate `services-vYYYY.MM.DD` release in `fdueblab/ioeb` only when linezolid or project services need production deployment.

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/ioeb-pycache python3 -m py_compile scripts/create-platform-release.py`
- `python3 scripts/create-platform-release.py release/platform-release.example.json`
- YAML parse check for `.github/workflows/master.yml`, `.github/workflows/docs.yml`, `.github/workflows/service.yml`
- `git diff --check`
- Verified DGL wheel URLs for pinned `2.3.0` and existing `2.2.1` return HTTP 200 for cp310/cp312.
