### PR TITLE
[codex] Add automated platform release workflow

### DIFF
--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -1,0 +1,233 @@
+name: Platform Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Dry run only, or create the production releases.
+        required: true
+        type: choice
+        default: dry-run
+        options:
+          - dry-run
+          - release
+      version:
+        description: Production version, for example v2026.06.24.
+        required: true
+        type: string
+      confirm_version:
+        description: Type the same version again when mode is release.
+        required: false
+        type: string
+      backend_ref:
+        description: fdueblab/ioeb_backend ref to release.
+        required: true
+        type: string
+        default: main
+      agent_ref:
+        description: fdueblab/Micro-Agent ref to release.
+        required: true
+        type: string
+        default: master
+      ioeb_ref:
+        description: fdueblab/ioeb ref to release.
+        required: true
+        type: string
+        default: master
+      summary:
+        description: Release summary.
+        required: false
+        type: string
+        default: Platform production release.
+      previous_version:
+        description: Previous production platform version for rollback notes.
+        required: false
+        type: string
+      database_backup:
+        description: Database backup identifier, or none.
+        required: false
+        type: string
+        default: none
+      run_health_checks:
+        description: Check dev and production health before release.
+        required: true
+        type: boolean
+        default: true
+      timeout_seconds:
+        description: Per-workflow wait timeout in seconds.
+        required: true
+        type: string
+        default: "2400"
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: Resolve Refs and Build Plan
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PLATFORM_RELEASE_TOKEN }}
+      VERSION: ${{ inputs.version }}
+      CONFIRM_VERSION: ${{ inputs.confirm_version }}
+      MODE: ${{ inputs.mode }}
+      BACKEND_REF: ${{ inputs.backend_ref }}
+      AGENT_REF: ${{ inputs.agent_ref }}
+      IOEB_REF: ${{ inputs.ioeb_ref }}
+      SUMMARY: ${{ inputs.summary }}
+      PREVIOUS_VERSION: ${{ inputs.previous_version }}
+      DATABASE_BACKUP: ${{ inputs.database_backup }}
+      RUN_HEALTH_CHECKS: ${{ inputs.run_health_checks }}
+      TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate inputs and token
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Missing repository secret PLATFORM_RELEASE_TOKEN."
+            exit 1
+          fi
+
+          if [ "${GITHUB_REF_NAME}" != "master" ]; then
+            echo "::error::Run this workflow from the master branch."
+            exit 1
+          fi
+
+          if ! [[ "${VERSION}" =~ ^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$ ]]; then
+            echo "::error::version must match vYYYY.MM.DD or vYYYY.MM.DD.N"
+            exit 1
+          fi
+
+          if [ "${MODE}" = "release" ] && [ "${CONFIRM_VERSION}" != "${VERSION}" ]; then
+            echo "::error::confirm_version must match version when mode is release."
+            exit 1
+          fi
+
+          if ! [[ "${TIMEOUT_SECONDS:-2400}" =~ ^[0-9]+$ ]]; then
+            echo "::error::timeout_seconds must be an integer."
+            exit 1
+          fi
+
+          gh auth status
+
+      - name: Run health checks
+        if: inputs.run_health_checks
+        run: |
+          set -euo pipefail
+          curl -fsSL --max-time 20 http://dev.fdueblab.cn/api/health
+          curl -fsSL --max-time 20 https://fdueblab.cn/api/health
+
+      - name: Resolve refs and generate manifest
+        run: |
+          set -euo pipefail
+
+          resolve_commit() {
+            local repo="$1"
+            local ref="$2"
+            local encoded
+            encoded="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "${ref}")"
+            gh api "repos/${repo}/commits/${encoded}" --jq .sha
+          }
+
+          BACKEND_SHA="$(resolve_commit fdueblab/ioeb_backend "${BACKEND_REF}")"
+          AGENT_SHA="$(resolve_commit fdueblab/Micro-Agent "${AGENT_REF}")"
+          IOEB_SHA="$(resolve_commit fdueblab/ioeb "${IOEB_REF}")"
+
+          export BACKEND_SHA AGENT_SHA IOEB_SHA
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          checks = ["release approved through Platform Release workflow"]
+          if os.environ["RUN_HEALTH_CHECKS"] == "true":
+              checks.extend([
+                  "dev health check passed before release",
+                  "production health check passed before release",
+              ])
+          else:
+              checks.append("health checks skipped by workflow input")
+
+          rollback = {
+              "databaseBackup": os.environ.get("DATABASE_BACKUP") or "none",
+          }
+          previous_version = os.environ.get("PREVIOUS_VERSION")
+          if previous_version:
+              rollback["previousVersion"] = previous_version
+
+          manifest = {
+              "version": os.environ["VERSION"],
+              "releaseOrder": ["backend", "agent", "frontend"],
+              "summary": os.environ.get("SUMMARY") or "Platform production release.",
+              "components": [
+                  {
+                      "name": "backend",
+                      "repo": "fdueblab/ioeb_backend",
+                      "ref": os.environ["BACKEND_SHA"],
+                      "deploys": ["backend"],
+                      "releaseWorkflows": ["CI"],
+                  },
+                  {
+                      "name": "agent",
+                      "repo": "fdueblab/Micro-Agent",
+                      "ref": os.environ["AGENT_SHA"],
+                      "deploys": ["agent"],
+                      "releaseWorkflows": ["CI"],
+                  },
+                  {
+                      "name": "frontend",
+                      "repo": "fdueblab/ioeb",
+                      "ref": os.environ["IOEB_SHA"],
+                      "deploys": ["frontend", "docs"],
+                      "releaseWorkflows": ["CI", "Build & Deploy Docs"],
+                  },
+              ],
+              "checks": checks,
+              "rollback": rollback,
+          }
+
+          Path("platform-release-manifest.json").write_text(
+              json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(manifest, ensure_ascii=False, indent=2))
+          PY
+
+      - name: Dry run release plan
+        run: |
+          set -euo pipefail
+          python3 scripts/create-platform-release.py platform-release-manifest.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: platform-release-manifest
+          path: platform-release-manifest.json
+          if-no-files-found: error
+
+  release:
+    name: Create Production Releases
+    if: inputs.mode == 'release'
+    needs: plan
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      GH_TOKEN: ${{ secrets.PLATFORM_RELEASE_TOKEN }}
+      TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: platform-release-manifest
+
+      - name: Create releases and wait for deployments
+        run: |
+          set -euo pipefail
+          python3 scripts/create-platform-release.py platform-release-manifest.json \
+            --execute \
+            --yes \
+            --timeout "${TIMEOUT_SECONDS}" \
+            --poll-interval 15

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -51,7 +51,38 @@ ioeb_backend -> Micro-Agent -> ioeb
 4. 周三创建生产 GitHub Release，触发生产部署。
 5. 发布后记录 release notes、已发布 commit、验证结果和回滚目标。
 
-## Release Manifest
+## 自动化发布
+
+推荐使用 `ioeb` 仓库的 `Platform Release` workflow 发生产版本。
+
+首次使用前需要在 `fdueblab/ioeb` 配置：
+
+- Repository secret `PLATFORM_RELEASE_TOKEN`：这个 token 需要能在 `fdueblab/ioeb_backend`、`fdueblab/Micro-Agent`、`fdueblab/ioeb` 三个仓库创建 GitHub Release，并读取 Actions 状态。Fine-grained token 至少需要三个仓库的 `Contents: Read and write` 和 `Actions: Read` 权限；classic token 可使用 `repo` scope。
+- GitHub Environment `production`：建议配置 required reviewers。workflow 的真正 release job 会绑定这个环境，因此可以在创建生产 release 前保留人工批准点。
+
+发布步骤：
+
+1. 打开 `fdueblab/ioeb` 的 GitHub Actions。
+2. 选择 `Platform Release`。
+3. 点击 `Run workflow`，分支选择 `master`。
+4. 先用 `mode=dry-run`，输入版本号，例如 `v2026.06.24`，确认生成的发布计划只包含 `backend`、`agent`、`frontend`、`docs`。
+5. 确认后再次运行，选择 `mode=release`，并在 `confirm_version` 输入同一个版本号。
+6. 如果 `production` 环境配置了 required reviewers，在 GitHub 页面批准 release job。
+7. 等待 workflow 创建三个仓库的同名 GitHub Release，并等待生产部署完成。
+
+默认 ref：
+
+| 输入 | 默认值 | 含义 |
+| --- | --- | --- |
+| `backend_ref` | `main` | `fdueblab/ioeb_backend` 发布 ref |
+| `agent_ref` | `master` | `fdueblab/Micro-Agent` 发布 ref |
+| `ioeb_ref` | `master` | `fdueblab/ioeb` 发布 ref |
+
+如需发布冻结版本，可以把这些输入改成具体 commit SHA。workflow 会自动把 ref 解析成固定 SHA 并写入 release manifest。
+
+## Release Manifest 手动发布
+
+一般不需要手动编辑 manifest。以下命令作为本地兜底方案保留。
 
 生产发布必须使用 release manifest 固定三个仓库的发布 commit。复制模板：
 


### PR DESCRIPTION
## What changed

- Add a manual `Platform Release` GitHub Actions workflow.
- The workflow resolves backend, agent, and ioeb refs to fixed commit SHAs.
- It generates a platform release manifest, runs a dry-run plan, uploads the manifest artifact, then optionally creates the production releases.
- The release job is bound to the `production` environment so repository environment protection can provide the human approval gate.
- Update release documentation with the new recommended GitHub Actions flow and keep the local manifest/script path as a fallback.

## Operator flow

After this PR is merged:

1. Open `fdueblab/ioeb` -> Actions -> `Platform Release`.
2. Run `mode=dry-run` first with a version such as `v2026.06.24`.
3. Re-run with `mode=release` and `confirm_version` set to the exact same version.
4. Approve the `production` environment job if required reviewers are configured.

## Required configuration

`fdueblab/ioeb` needs a repository secret named `PLATFORM_RELEASE_TOKEN`.

The token must be able to create releases and read Actions status in:

- `fdueblab/ioeb_backend`
- `fdueblab/Micro-Agent`
- `fdueblab/ioeb`

Fine-grained token permissions: `Contents: Read and write`, `Actions: Read`.
Classic token scope: `repo`.

## Validation

- Parsed `.github/workflows/platform-release.yml` as YAML.
- `python3 -m py_compile scripts/create-platform-release.py`
- `python3 scripts/create-platform-release.py release/platform-release.example.json`
- `git diff --check`
