### PR TITLE
[codex] Restore docs top navigation

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -93,13 +93,12 @@ export default defineConfig({
     },
 
     // 设置导航栏
-    // nav: [
-    //   { text: '首页', link: '/' },
-    //   { text: '快速开始', link: '/quickstart' },
-    //   { text: '用户指南', link: '/guide/' },
-    //   { text: '开发指南', link: '/dev/' },
-    //   { text: '常见问题', link: '/faq' },
-    // ],
+    nav: [
+      { text: '首页', link: '/' },
+      { text: '用户指南', link: '/guide/' },
+      { text: '开发指南', link: '/dev/' },
+      { text: '常见问题', link: '/faq' },
+    ],
 
     // 设置侧边栏
     sidebar: {


### PR DESCRIPTION
## What changed

- Restore the VitePress top navigation menu in `docs/.vitepress/config.mjs`.
- Keep the existing sidebar changes and report document intact.

## Why

The docs config had the top-level `nav` block commented out, so the upper-right navigation did not render.

## Validation

- `npm --prefix docs run build -- --outDir /tmp/ioeb-docs-dist-nav`
- Verified generated HTML contains `首页`, `用户指南`, `开发指南`, and `常见问题` in the VitePress nav.
- `git diff --check`
