### PR TITLE
fix: use environment-specific docs links

### DIFF
--- a/src/config/router.config.js
+++ b/src/config/router.config.js
@@ -4,6 +4,7 @@ import { bxAnaalyse } from '@/core/icons'
 import { loadDict } from '@/utils/dictionaryCache'
 import { getDefaultLandingPath } from '@/utils/domainContext'
 import { getPreferredVertical } from '@/api/userProfile'
+import { buildDocsUrl } from '@/utils/baseUrl'
 
 const RouteView = {
   name: 'RouteView',
@@ -932,7 +933,7 @@ export const asyncRouterMap = [
       //   ]
       // },
       {
-        path: 'https://fdueblab.cn/docs',
+        path: buildDocsUrl(),
         name: 'guide',
         meta: {
           title: '使用指南',

--- a/src/utils/baseUrl.js
+++ b/src/utils/baseUrl.js
@@ -23,8 +23,14 @@ export const resolveRuntimeBaseUrl = (configuredValue, fallbackPath = '') => {
 
 export const API_BASE_URL = resolveRuntimeBaseUrl(process.env.VUE_APP_API_BASE_URL, '/api')
 export const AGENT_BASE_URL = resolveRuntimeBaseUrl(process.env.VUE_APP_AGENT_BASE_URL, '')
+export const DOCS_BASE_URL = resolveRuntimeBaseUrl(process.env.VUE_APP_DOCS_BASE_URL, '/docs')
 
 export const buildServiceApiUrl = (serviceUrl) => {
   const normalizedServiceUrl = String(serviceUrl || '').replace(/^\/+/, '')
   return `${API_BASE_URL}/${normalizedServiceUrl}`
+}
+
+export const buildDocsUrl = (docsPath = '') => {
+  const normalizedDocsPath = String(docsPath || '').replace(/^\/+|\/+$/g, '')
+  return normalizedDocsPath ? `${DOCS_BASE_URL}/${normalizedDocsPath}` : `${DOCS_BASE_URL}/`
 }

--- a/src/views/dashboard/Workplace.vue
+++ b/src/views/dashboard/Workplace.vue
@@ -152,6 +152,7 @@ import {
   getDomainModuleEntryPath
 } from '@/utils/domainContext'
 import { getRecentRoutes } from '@/utils/recentRoutes'
+import { buildDocsUrl } from '@/utils/baseUrl'
 
 export default {
   name: 'Workplace',
@@ -306,7 +307,7 @@ export default {
       this.$router.push({ path }).catch(() => {})
     },
     openDocs () {
-      window.open('https://fdueblab.cn/docs', '_blank')
+      window.open(buildDocsUrl(), '_blank')
     }
   }
 }

--- a/src/views/vertical/ms/GenericMicroService.vue
+++ b/src/views/vertical/ms/GenericMicroService.vue
@@ -17,7 +17,7 @@
                   v-show="submitType === 'algorithm'"
                   type="link"
                   icon="file-text"
-                  href="https://fdueblab.cn/docs/guide/code-template"
+                  :href="codeTemplateDocUrl"
                   target="_blank"
                 >
                   算法代码提交要求文档
@@ -538,6 +538,7 @@ import AgentExecutionPanel from '@/components/Agent/AgentExecutionPanel'
 import dictionaryCache from '@/utils/dictionaryCache'
 import { createService } from '@/api/service'
 import store from '@/store'
+import { buildDocsUrl } from '@/utils/baseUrl'
 
 export default {
   name: 'GenericMicroService',
@@ -642,6 +643,9 @@ export default {
     }
   },
   computed: {
+    codeTemplateDocUrl() {
+      return buildDocsUrl('guide/code-template')
+    },
     uploadServiceDisabled() {
       if (this.submitType === 'microservice') {
         return !this.form.serviceName || this.uploadFiles.length === 0


### PR DESCRIPTION
## Summary
- add shared docs URL builder that resolves to the current runtime origin by default
- make the sidebar 使用指南 link open the current environment docs instead of production docs
- update dashboard and microservice publish docs buttons to use the same environment-aware docs URL

## Verification
- npm run build
- ./node_modules/.bin/eslint src/utils/baseUrl.js src/config/router.config.js src/views/dashboard/Workplace.vue src/views/vertical/ms/GenericMicroService.vue
- rg -n "fdueblab\.cn/docs" src -S returns no matches