### PR TITLE
[codex] Fix domain switch routing

### DIFF
--- a/src/config/router.config.js
+++ b/src/config/router.config.js
@@ -3,7 +3,6 @@ import { UserLayout, BasicLayout, BlankLayout, AppView } from '@/layouts'
 import { bxAnaalyse } from '@/core/icons'
 import { loadDict } from '@/utils/dictionaryCache'
 import { getDefaultLandingPath } from '@/utils/domainContext'
-import { getPreferredVertical } from '@/api/userProfile'
 import { buildDocsUrl } from '@/utils/baseUrl'
 
 const RouteView = {
@@ -12,34 +11,19 @@ const RouteView = {
 }
 
 const DEFAULT_VERTICAL_DOMAIN = { code: 'aml', text: '跨境支付AI监测' }
-const OPENED_VERTICAL_LABELS = {
-  aml: '跨境支付AI监测',
-  health: '心理健康分析'
-}
 
-function normalizePreferredVertical(code) {
-  return Object.prototype.hasOwnProperty.call(OPENED_VERTICAL_LABELS, code) ? code : DEFAULT_VERTICAL_DOMAIN.code
-}
-
-function filterDomainsByPreference(domains = []) {
-  const preferred = normalizePreferredVertical(getPreferredVertical())
-  const hit = (domains || []).find(domain => domain.code === preferred)
-  if (hit) return [hit]
-  return [{ code: preferred, text: OPENED_VERTICAL_LABELS[preferred] || DEFAULT_VERTICAL_DOMAIN.text }]
-}
-
-async function loadPreferredDomains() {
+async function loadAvailableDomains() {
   const domains = await loadDict('domain', [])
   if (!domains || domains.length === 0) {
     return [DEFAULT_VERTICAL_DOMAIN]
   }
-  return filterDomainsByPreference(domains)
+  return domains
 }
 
 // 获取垂域路由的第一个路径，用于重定向
 export async function getFirstVerticalUserPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/vertical-user/${domains[0].code}`
     }
@@ -53,7 +37,7 @@ export async function getFirstVerticalUserPath() {
 export async function generateVerticalUserRoutes() {
   try {
     // 从字典加载"domain"类别的数据
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
 
     // 如果字典为空，返回至少一个默认路由（防止路由为空）
     if (!domains || domains.length === 0) {
@@ -91,7 +75,7 @@ export async function generateVerticalUserRoutes() {
 export async function generateVerticalMSRoutes() {
   try {
     // 从字典加载"domain"类别的数据
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
 
     // 如果字典为空，返回至少一个默认路由（防止路由为空）
     if (!domains || domains.length === 0) {
@@ -129,7 +113,7 @@ export async function generateVerticalMSRoutes() {
 export async function generateVerticalAppRoutes() {
   try {
     // 从字典加载"domain"类别的数据
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
 
     // 如果字典为空，返回至少一个默认路由（防止路由为空）
     if (!domains || domains.length === 0) {
@@ -171,7 +155,7 @@ export async function generateVerticalAppRoutes() {
 export async function generateGuideRoutes() {
   try {
     // 从字典加载"domain"类别的数据
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
 
     // 如果字典为空，返回至少一个默认路由（防止路由为空）
     if (!domains || domains.length === 0) {
@@ -207,7 +191,7 @@ export async function generateGuideRoutes() {
 
 export async function getFirstMSPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/vertical-ms/${domains[0].code}`
     }
@@ -220,7 +204,7 @@ export async function getFirstMSPath() {
 // 获取想定式开发路由的第一个路径，用于重定向
 export async function getFirstScenarioDevPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/vertical-scenario-dev/${domains[0].code}`
     }
@@ -233,7 +217,7 @@ export async function getFirstScenarioDevPath() {
 // 动态生成算法模型想定式开发路由的辅助函数
 export async function generateVerticalScenarioDevRoutes() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (!domains || domains.length === 0) {
       return [{
         path: '/vertical-scenario-dev/aml',
@@ -264,7 +248,7 @@ export async function generateVerticalScenarioDevRoutes() {
 
 export async function getFirstAppPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/vertical-atom-app/${domains[0].code}`
     }
@@ -278,7 +262,7 @@ export async function getFirstAppPath() {
 export async function generateEvaluationRoutes() {
   try {
     // 从字典加载"domain"类别的数据
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
 
     // 如果字典为空，返回至少一个默认路由（防止路由为空）
     if (!domains || domains.length === 0) {
@@ -359,7 +343,7 @@ export async function generateEvaluationRoutes() {
 
 export async function getFirstTechnologyPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/evaluation/${domains[0].code}/technology`
     }
@@ -371,7 +355,7 @@ export async function getFirstTechnologyPath() {
 
 export async function getFirstEvaluationPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/evaluation/${domains[0].code}/technology`
     }
@@ -385,7 +369,7 @@ export async function getFirstEvaluationPath() {
 export async function generateOperationRoutes() {
   try {
     // 从字典加载"domain"类别的数据
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
 
     // 如果字典为空，返回至少一个默认路由（防止路由为空）
     if (!domains || domains.length === 0) {
@@ -466,7 +450,7 @@ export async function generateOperationRoutes() {
 
 export async function getFirstOperationPath() {
   try {
-    const domains = await loadPreferredDomains()
+    const domains = await loadAvailableDomains()
     if (domains && domains.length > 0) {
       return `/operation/${domains[0].code}/container-status`
     }


### PR DESCRIPTION
## Summary

- Remove the user-profile preferred-vertical filter from dynamic domain route generation.
- Generate vertical-domain routes from the full `domain` dictionary so every user can access all configured domains by default.
- Keep the existing fallback to the AML domain when the domain dictionary is unavailable.

## Root Cause

The header domain selector loaded and displayed the full domain dictionary, but the router only registered routes for the single `preferredVertical` stored in the user profile. Selecting another domain pushed a URL that was not registered in Vue Router, which fell through to the 404 route.

## Impact

The right-header domain selector is no longer coupled to the user profile. Switching domains now targets routes that are registered for all configured domains.

## Validation

- `npm run build` passed.
- Build completed with existing asset-size warnings only.
