### PR TITLE
fix login e2e readiness wait

### DIFF
--- a/docs/dev/e2e-testing-report.md
+++ b/docs/dev/e2e-testing-report.md
@@ -298,10 +298,14 @@ yarn test:e2e:ui
 const { test, expect } = require('@playwright/test')
 
 test('test user can open workplace page', async ({ page }) => {
-  await page.goto('/user/login')
+  await page.goto('/user/login', { waitUntil: 'domcontentloaded' })
 
-  await page.getByPlaceholder('请输入账户名').fill(process.env.E2E_USERNAME)
-  await page.getByPlaceholder('请输入密码').fill(process.env.E2E_PASSWORD)
+  const usernameInput = page.getByPlaceholder('请输入账户名')
+  const passwordInput = page.getByPlaceholder('请输入密码')
+
+  await expect(usernameInput).toBeVisible()
+  await usernameInput.fill(process.env.E2E_USERNAME)
+  await passwordInput.fill(process.env.E2E_PASSWORD)
   await page.getByRole('button', { name: /登\s*录/ }).click()
 
   await expect(page).toHaveURL(/#\/account\/workplace/)

--- a/tests/e2e/login.spec.js
+++ b/tests/e2e/login.spec.js
@@ -17,10 +17,14 @@ test('test user can sign in through the login page', async ({ page }) => {
   const username = requireEnv('E2E_USERNAME')
   const password = requireEnv('E2E_PASSWORD')
 
-  await page.goto('/user/login')
+  await page.goto('/user/login', { waitUntil: 'domcontentloaded' })
 
-  await page.getByPlaceholder('请输入账户名').fill(username)
-  await page.getByPlaceholder('请输入密码').fill(password)
+  const usernameInput = page.getByPlaceholder('请输入账户名')
+  const passwordInput = page.getByPlaceholder('请输入密码')
+
+  await expect(usernameInput).toBeVisible()
+  await usernameInput.fill(username)
+  await passwordInput.fill(password)
   await page.getByRole('button', { name: /登\s*录/ }).click()
 
   await expect(page).toHaveURL(/#\/account\/workplace/)


### PR DESCRIPTION
## Summary
- make the login E2E navigation wait for `domcontentloaded` instead of the full page `load` event
- wait for the username input to be visible before filling credentials
- update the E2E testing report example with the same readiness pattern

## Root Cause
The post-merge master CI failed in `Login E2E` because `page.goto('/user/login')` waited for the full `load` event. The Playwright failure artifact showed the login form was already visible, while a third-party page resource was still preventing the `load` wait from completing within 30 seconds.

## Validation
- `git diff --check`
- `E2E_BASE_URL=... E2E_USERNAME=... E2E_PASSWORD=... npx yarn@1.22.22 test:e2e tests/e2e/login.spec.js`
- `npx yarn@1.22.22 --ignore-engines docs:build`