### PR TITLE
fix: wait for actual MCP deployment result

### DIFF
--- a/src/utils/serviceDeployment.js
+++ b/src/utils/serviceDeployment.js
@@ -1,0 +1,64 @@
+const DEPLOYMENT_SUCCESS_STATUSES = new Set([
+  'pre_release_unrated',
+  'pre_release_pending',
+  'released'
+])
+
+const DEPLOYMENT_FAILURE_STATUSES = new Set([
+  'error',
+  'not_deployed'
+])
+
+const defaultSleep = (milliseconds) => new Promise(resolve => {
+  setTimeout(resolve, milliseconds)
+})
+
+export async function waitForServiceDeployment(fetchService, options = {}) {
+  const timeoutMs = options.timeoutMs || 15 * 60 * 1000
+  const intervalMs = options.intervalMs || 3000
+  const maxConsecutiveErrors = options.maxConsecutiveErrors || 3
+  const now = options.now || Date.now
+  const sleep = options.sleep || defaultSleep
+  const onStatus = options.onStatus || (() => {})
+  const startedAt = now()
+  let consecutiveErrors = 0
+
+  while (true) {
+    try {
+      const response = await fetchService()
+      const service = response && response.service
+      if (!service || !service.status) {
+        throw new Error('查询部署状态返回了无效数据')
+      }
+
+      consecutiveErrors = 0
+      onStatus(service.status, service)
+
+      if (DEPLOYMENT_SUCCESS_STATUSES.has(service.status)) {
+        return service
+      }
+      if (DEPLOYMENT_FAILURE_STATUSES.has(service.status)) {
+        throw new Error('服务容器或 MCP 端点启动失败，请查看后端部署日志')
+      }
+      if (service.status !== 'deploying') {
+        throw new Error(`服务进入了非预期状态：${service.status}`)
+      }
+    } catch (error) {
+      if (
+        error.message.includes('启动失败') ||
+        error.message.includes('非预期状态')
+      ) {
+        throw error
+      }
+      consecutiveErrors += 1
+      if (consecutiveErrors >= maxConsecutiveErrors) {
+        throw new Error(`连续查询部署状态失败：${error.message || error}`)
+      }
+    }
+
+    if (now() - startedAt >= timeoutMs) {
+      throw new Error('等待服务部署完成超时，请稍后在服务管理中查看状态')
+    }
+    await sleep(intervalMs)
+  }
+}

--- a/src/views/vertical/ms/GenericMicroService.vue
+++ b/src/views/vertical/ms/GenericMicroService.vue
@@ -585,9 +585,10 @@ import * as echarts from 'echarts'
 import vChart from 'vue-echarts'
 import AgentExecutionPanel from '@/components/Agent/AgentExecutionPanel'
 import dictionaryCache from '@/utils/dictionaryCache'
-import { createService, downloadScenarioGeneratedAlgorithm, filterServices } from '@/api/service'
+import { createService, downloadScenarioGeneratedAlgorithm, filterServices, getServiceById } from '@/api/service'
 import store from '@/store'
 import { buildDocsUrl } from '@/utils/baseUrl'
+import { waitForServiceDeployment } from '@/utils/serviceDeployment'
 
 export default {
   name: 'GenericMicroService',
@@ -1419,7 +1420,26 @@ export default {
         const response = await this.uploadAndDeployService(formData)
         
         if (response && response.status === 'success') {
-          return response
+          const serviceId = response.service && response.service.id
+          if (!serviceId) {
+            throw new Error('部署任务已提交，但后端没有返回服务ID')
+          }
+
+          const deployedService = await waitForServiceDeployment(
+            () => getServiceById(serviceId),
+            {
+              onStatus: status => {
+                if (status === 'deploying') {
+                  this.updatePublishProgress(
+                    3,
+                    'process',
+                    '容器正在构建，等待 MCP 服务端点就绪...'
+                  )
+                }
+              }
+            }
+          )
+          return { ...response, service: deployedService }
         } else {
           throw new Error(response?.message || '部署失败')
         }

--- a/tests/unit/serviceDeployment.spec.js
+++ b/tests/unit/serviceDeployment.spec.js
@@ -1,0 +1,38 @@
+import { waitForServiceDeployment } from '@/utils/serviceDeployment'
+
+const noWait = () => Promise.resolve()
+
+describe('waitForServiceDeployment', () => {
+  test('waits until the backend reports a deploy success state', async () => {
+    const fetchService = jest.fn()
+      .mockResolvedValueOnce({ service: { id: 'service-1', status: 'deploying' } })
+      .mockResolvedValueOnce({ service: { id: 'service-1', status: 'pre_release_unrated' } })
+    const statuses = []
+
+    const service = await waitForServiceDeployment(fetchService, {
+      sleep: noWait,
+      onStatus: status => statuses.push(status)
+    })
+
+    expect(service.status).toBe('pre_release_unrated')
+    expect(fetchService).toHaveBeenCalledTimes(2)
+    expect(statuses).toEqual(['deploying', 'pre_release_unrated'])
+  })
+
+  test('rejects when the backend reports deployment error', async () => {
+    await expect(waitForServiceDeployment(
+      () => Promise.resolve({ service: { id: 'service-1', status: 'error' } }),
+      { sleep: noWait }
+    )).rejects.toThrow('MCP 端点启动失败')
+  })
+
+  test('tolerates a transient status request failure', async () => {
+    const fetchService = jest.fn()
+      .mockRejectedValueOnce(new Error('temporary network error'))
+      .mockResolvedValueOnce({ service: { id: 'service-1', status: 'released' } })
+
+    const service = await waitForServiceDeployment(fetchService, { sleep: noWait })
+
+    expect(service.status).toBe('released')
+  })
+})


### PR DESCRIPTION
## What changed
- the existing publish UI now polls the service record after upload
- success is shown only after the backend reports a deployed/pre-release state
- backend error and timeout states remain visible as publish failures
- transient status-query failures are retried

## Why
The frontend previously interpreted task submission as completed deployment, producing an immediate false-success result while Docker was still building or had already failed.

## Validation
- deployment polling unit tests: 3 passed
- targeted ESLint: passed
- production frontend build: passed